### PR TITLE
Feat: 공통 예외 처리 로직 구현

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/common/error/dto/ErrorResponse.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/dto/ErrorResponse.java
@@ -1,0 +1,30 @@
+package com.goodseats.seatviewreviews.common.error.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public record ErrorResponse(
+		int status,
+		String url,
+		String exceptionName,
+		String message,
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+		LocalDateTime createdAt,
+		List<FieldError> fieldErrors
+) {
+
+	public record FieldError(String fieldName, Object rejectedValue, String message) {
+	}
+
+	public static ErrorResponse of(
+			int status,
+			String url,
+			String exceptionName,
+			String message,
+			List<FieldError> fieldErrors
+	) {
+		return new ErrorResponse(status, url, exceptionName, message, LocalDateTime.now(), fieldErrors);
+	}
+}

--- a/src/main/java/com/goodseats/seatviewreviews/common/error/dto/ErrorResponse.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/dto/ErrorResponse.java
@@ -12,18 +12,14 @@ public record ErrorResponse(
 		String message,
 		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
 		LocalDateTime createdAt,
-		List<FieldError> fieldErrors
+		List<FieldErrorResponse> fieldErrors
 ) {
-
-	public record FieldError(String fieldName, Object rejectedValue, String message) {
-	}
-
 	public static ErrorResponse of(
 			int status,
 			String url,
 			String exceptionName,
 			String message,
-			List<FieldError> fieldErrors
+			List<FieldErrorResponse> fieldErrors
 	) {
 		return new ErrorResponse(status, url, exceptionName, message, LocalDateTime.now(), fieldErrors);
 	}

--- a/src/main/java/com/goodseats/seatviewreviews/common/error/dto/FieldErrorResponse.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/dto/FieldErrorResponse.java
@@ -1,0 +1,4 @@
+package com.goodseats.seatviewreviews.common.error.dto;
+
+public record FieldErrorResponse(String fieldName, Object rejectedValue, String message) {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/common/error/exception/BusinessException.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/exception/BusinessException.java
@@ -1,24 +1,19 @@
 package com.goodseats.seatviewreviews.common.error.exception;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.Getter;
 
 @Getter
 public class BusinessException extends RuntimeException {
 
-	protected HttpStatus status;
-	protected String message;
+	private final ErrorCode errorCode;
 
-	public BusinessException(HttpStatus status, String message) {
-		super(message);
-		this.status = status;
-		this.message = message;
+	public BusinessException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
 	}
 
-	public BusinessException(HttpStatus status, String message, Throwable cause) {
-		super(message, cause);
-		this.status = status;
-		this.message = message;
+	public BusinessException(ErrorCode errorCode, Throwable cause) {
+		super(errorCode.getMessage(), cause);
+		this.errorCode = errorCode;
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/common/error/exception/BusinessException.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/exception/BusinessException.java
@@ -1,0 +1,24 @@
+package com.goodseats.seatviewreviews.common.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+	protected HttpStatus status;
+	protected String message;
+
+	public BusinessException(HttpStatus status, String message) {
+		super(message);
+		this.status = status;
+		this.message = message;
+	}
+
+	public BusinessException(HttpStatus status, String message, Throwable cause) {
+		super(message, cause);
+		this.status = status;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/goodseats/seatviewreviews/common/error/exception/ErrorCode.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/exception/ErrorCode.java
@@ -1,0 +1,17 @@
+package com.goodseats.seatviewreviews.common.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+	NOT_FOUND(404, "존재하지 않는 데이터입니다.");
+
+	private final int status;
+	private final String message;
+
+	ErrorCode(int status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/goodseats/seatviewreviews/common/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/handler/GlobalExceptionHandler.java
@@ -26,12 +26,66 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.goodseats.seatviewreviews.common.error.dto.ErrorResponse;
 import com.goodseats.seatviewreviews.common.error.dto.FieldErrorResponse;
+import com.goodseats.seatviewreviews.common.error.exception.BusinessException;
 
 import lombok.extern.slf4j.Slf4j;
 
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
+
+	@ExceptionHandler(NullPointerException.class)
+	public ResponseEntity<ErrorResponse> handleNullPointException(HttpServletRequest request, NullPointerException e) {
+		logInfo(e, request.getRequestURI());
+
+		return ResponseEntity
+				.badRequest()
+				.body(
+						of(
+								BAD_REQUEST.value(),
+								request.getRequestURI(),
+								e.getClass().getSimpleName(),
+								e.getMessage(),
+								null
+						)
+				);
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
+			HttpServletRequest request, IllegalArgumentException e) {
+		logInfo(e, request.getRequestURI());
+
+		return ResponseEntity
+				.badRequest()
+				.body(
+						ErrorResponse.of(
+								BAD_REQUEST.value(),
+								request.getRequestURI(),
+								e.getClass().getSimpleName(),
+								e.getMessage(),
+								null
+						)
+				);
+	}
+
+	@ExceptionHandler(InvalidFormatException.class)
+	public ResponseEntity<ErrorResponse> handleInvalidFormatException(
+			HttpServletRequest request, InvalidFormatException e) {
+		logInfo(e, request.getRequestURI());
+
+		return ResponseEntity
+				.badRequest()
+				.body(
+						ErrorResponse.of(
+								BAD_REQUEST.value(),
+								request.getRequestURI(),
+								e.getClass().getSimpleName(),
+								e.getMessage(),
+								null
+						)
+				);
+	}
 
 	@ExceptionHandler(DataIntegrityViolationException.class)
 	public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(
@@ -66,24 +120,11 @@ public class GlobalExceptionHandler {
 								request.getRequestURI(),
 								e.getClass().getSimpleName(),
 								e.getMessage(),
-								List.of(new FieldErrorResponse(e.getName(), Objects.requireNonNull(e.getValue()).toString(), e.getMessage()))
-						)
-				);
-	}
-
-	@ExceptionHandler(NullPointerException.class)
-	public ResponseEntity<ErrorResponse> handleNullPointException(HttpServletRequest request, NullPointerException e) {
-		logInfo(e, request.getRequestURI());
-
-		return ResponseEntity
-				.badRequest()
-				.body(
-						of(
-								BAD_REQUEST.value(),
-								request.getRequestURI(),
-								e.getClass().getSimpleName(),
-								e.getMessage(),
-								null
+								List.of(
+										new FieldErrorResponse(
+												e.getName(), Objects.requireNonNull(e.getValue()).toString(), e.getMessage()
+										)
+								)
 						)
 				);
 	}
@@ -145,34 +186,17 @@ public class GlobalExceptionHandler {
 				);
 	}
 
-	@ExceptionHandler(IllegalArgumentException.class)
-	public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
-			HttpServletRequest request, IllegalArgumentException e) {
+	@ExceptionHandler(BusinessException.class)
+	public ResponseEntity<ErrorResponse> handleBusinessException(
+			HttpServletRequest request, BusinessException e
+	) {
 		logInfo(e, request.getRequestURI());
 
 		return ResponseEntity
-				.badRequest()
+				.status(e.getErrorCode().getStatus())
 				.body(
 						ErrorResponse.of(
-								BAD_REQUEST.value(),
-								request.getRequestURI(),
-								e.getClass().getSimpleName(),
-								e.getMessage(),
-								null
-						)
-				);
-	}
-
-	@ExceptionHandler(InvalidFormatException.class)
-	public ResponseEntity<ErrorResponse> handleInvalidFormatException(
-			HttpServletRequest request, InvalidFormatException e) {
-		logInfo(e, request.getRequestURI());
-
-		return ResponseEntity
-				.badRequest()
-				.body(
-						ErrorResponse.of(
-								BAD_REQUEST.value(),
+								e.getErrorCode().getStatus(),
 								request.getRequestURI(),
 								e.getClass().getSimpleName(),
 								e.getMessage(),

--- a/src/main/java/com/goodseats/seatviewreviews/common/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/handler/GlobalExceptionHandler.java
@@ -25,6 +25,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.goodseats.seatviewreviews.common.error.dto.ErrorResponse;
+import com.goodseats.seatviewreviews.common.error.dto.FieldErrorResponse;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -65,7 +66,7 @@ public class GlobalExceptionHandler {
 								request.getRequestURI(),
 								e.getClass().getSimpleName(),
 								e.getMessage(),
-								List.of(new FieldError(e.getName(), Objects.requireNonNull(e.getValue()).toString(), e.getMessage()))
+								List.of(new FieldErrorResponse(e.getName(), Objects.requireNonNull(e.getValue()).toString(), e.getMessage()))
 						)
 				);
 	}
@@ -214,11 +215,11 @@ public class GlobalExceptionHandler {
 				);
 	}
 
-	private List<ErrorResponse.FieldError> makeFieldErrorsFromBindingResult(BindingResult bindingResult) {
+	private List<FieldErrorResponse> makeFieldErrorsFromBindingResult(BindingResult bindingResult) {
 
 		return bindingResult.getFieldErrors()
 				.stream()
-				.map(error -> new ErrorResponse.FieldError(
+				.map(error -> new FieldErrorResponse(
 						error.getField(),
 						error.getRejectedValue(),
 						error.getDefaultMessage()
@@ -226,11 +227,11 @@ public class GlobalExceptionHandler {
 				.toList();
 	}
 
-	private List<ErrorResponse.FieldError> makeFieldErrorsFromConstraintViolation(
+	private List<FieldErrorResponse> makeFieldErrorsFromConstraintViolation(
 			Set<ConstraintViolation<?>> constraintViolations
 	) {
 		return constraintViolations.stream()
-				.map(violation -> new ErrorResponse.FieldError(
+				.map(violation -> new FieldErrorResponse(
 						getFieldFromPath(violation.getPropertyPath()),
 						violation.getInvalidValue().toString(),
 						violation.getMessage()

--- a/src/main/java/com/goodseats/seatviewreviews/common/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/handler/GlobalExceptionHandler.java
@@ -1,0 +1,257 @@
+package com.goodseats.seatviewreviews.common.error.handler;
+
+import static com.goodseats.seatviewreviews.common.error.dto.ErrorResponse.*;
+import static org.springframework.http.HttpStatus.*;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Path;
+
+import org.hibernate.validator.internal.engine.path.PathImpl;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.goodseats.seatviewreviews.common.error.dto.ErrorResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(DataIntegrityViolationException.class)
+	public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(
+			HttpServletRequest request, DataIntegrityViolationException e
+	) {
+		logInfo(e, request.getRequestURI());
+
+		return ResponseEntity
+				.status(HttpStatus.CONFLICT)
+				.body(
+						of(
+								HttpStatus.CONFLICT.value(),
+								request.getRequestURI(),
+								e.getClass().getSimpleName(),
+								e.getMessage(),
+								null
+						)
+				);
+	}
+
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+			HttpServletRequest request, MethodArgumentTypeMismatchException e
+	) {
+		logInfo(e, request.getRequestURI());
+
+		return ResponseEntity
+				.badRequest()
+				.body(
+						of(
+								BAD_REQUEST.value(),
+								request.getRequestURI(),
+								e.getClass().getSimpleName(),
+								e.getMessage(),
+								List.of(new FieldError(e.getName(), Objects.requireNonNull(e.getValue()).toString(), e.getMessage()))
+						)
+				);
+	}
+
+	@ExceptionHandler(NullPointerException.class)
+	public ResponseEntity<ErrorResponse> handleNullPointException(HttpServletRequest request, NullPointerException e) {
+		logInfo(e, request.getRequestURI());
+
+		return ResponseEntity
+				.badRequest()
+				.body(
+						of(
+								BAD_REQUEST.value(),
+								request.getRequestURI(),
+								e.getClass().getSimpleName(),
+								e.getMessage(),
+								null
+						)
+				);
+	}
+
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<ErrorResponse> handleConstraintViolationException(
+			HttpServletRequest request, ConstraintViolationException e
+	) {
+		logInfo(e, request.getRequestURI());
+
+		return ResponseEntity
+				.badRequest()
+				.body(
+						of(
+								BAD_REQUEST.value(),
+								request.getRequestURI(),
+								e.getClass().getSimpleName(),
+								e.getMessage(),
+								makeFieldErrorsFromConstraintViolation(e.getConstraintViolations())
+						)
+				);
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+			HttpServletRequest request, MethodArgumentNotValidException e
+	) {
+		logInfo(e, request.getRequestURI());
+
+		return ResponseEntity
+				.badRequest()
+				.body(
+						ErrorResponse.of(
+								BAD_REQUEST.value(),
+								request.getRequestURI(),
+								e.getClass().getSimpleName(),
+								e.getMessage(),
+								makeFieldErrorsFromBindingResult(e.getBindingResult())
+						)
+				);
+	}
+
+	@ExceptionHandler(BindException.class)
+	public ResponseEntity<ErrorResponse> handleBindException(
+			HttpServletRequest request, BindException e
+	) {
+		logInfo(e, request.getRequestURI());
+
+		return ResponseEntity
+				.badRequest()
+				.body(
+						ErrorResponse.of(
+								BAD_REQUEST.value(),
+								request.getRequestURI(),
+								e.getClass().getSimpleName(),
+								e.getMessage(),
+								makeFieldErrorsFromBindingResult(e.getBindingResult())
+						)
+				);
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
+			HttpServletRequest request, IllegalArgumentException e) {
+		logInfo(e, request.getRequestURI());
+
+		return ResponseEntity
+				.badRequest()
+				.body(
+						ErrorResponse.of(
+								BAD_REQUEST.value(),
+								request.getRequestURI(),
+								e.getClass().getSimpleName(),
+								e.getMessage(),
+								null
+						)
+				);
+	}
+
+	@ExceptionHandler(InvalidFormatException.class)
+	public ResponseEntity<ErrorResponse> handleInvalidFormatException(
+			HttpServletRequest request, InvalidFormatException e) {
+		logInfo(e, request.getRequestURI());
+
+		return ResponseEntity
+				.badRequest()
+				.body(
+						ErrorResponse.of(
+								BAD_REQUEST.value(),
+								request.getRequestURI(),
+								e.getClass().getSimpleName(),
+								e.getMessage(),
+								null
+						)
+				);
+	}
+
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<ErrorResponse> handleRuntimeException(HttpServletRequest request, RuntimeException e) {
+		logWarn(e, request.getRequestURI());
+
+		return ResponseEntity
+				.badRequest()
+				.body(
+						of(
+								BAD_REQUEST.value(),
+								request.getRequestURI(),
+								e.getClass().getSimpleName(),
+								e.getMessage(),
+								null
+						)
+				);
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
+		logError(e, request.getRequestURI());
+
+		return ResponseEntity
+				.internalServerError()
+				.body(
+						of(
+								HttpStatus.INTERNAL_SERVER_ERROR.value(),
+								request.getRequestURI(),
+								e.getClass().getSimpleName(),
+								e.getMessage(),
+								null
+						)
+				);
+	}
+
+	private List<ErrorResponse.FieldError> makeFieldErrorsFromBindingResult(BindingResult bindingResult) {
+
+		return bindingResult.getFieldErrors()
+				.stream()
+				.map(error -> new ErrorResponse.FieldError(
+						error.getField(),
+						error.getRejectedValue(),
+						error.getDefaultMessage()
+				))
+				.toList();
+	}
+
+	private List<ErrorResponse.FieldError> makeFieldErrorsFromConstraintViolation(
+			Set<ConstraintViolation<?>> constraintViolations
+	) {
+		return constraintViolations.stream()
+				.map(violation -> new ErrorResponse.FieldError(
+						getFieldFromPath(violation.getPropertyPath()),
+						violation.getInvalidValue().toString(),
+						violation.getMessage()
+				))
+				.toList();
+	}
+
+	private String getFieldFromPath(Path fieldPath) {
+		PathImpl pathImpl = (PathImpl)fieldPath;
+		return pathImpl.getLeafNode().toString();
+	}
+
+	private void logInfo(Exception e, String url) {
+		log.info("URL = {}, Exception = {}, Message = {}", url, e.getClass().getSimpleName(), e.getMessage());
+	}
+
+	private void logWarn(Exception e, String url) {
+		log.info("URL = {}, Exception = {}, Message = {}", url, e.getClass().getSimpleName(), e.getMessage());
+	}
+
+	private void logError(Exception e, String url) {
+		log.info("URL = {}, Exception = {}, Message = {}", url, e.getClass().getSimpleName(), e.getMessage());
+	}
+}


### PR DESCRIPTION
### 관련 이슈
- close #2 

### 내용
- 예외 발생 시 보여줄 정보의 종류와 형식을 자유롭게 하기 위해 ErrorResponse 를 커스텀 함.
- 최상위 BusinessException 과 계층화된 하위 커스텀 예외들로 구성되도록 예외 관리 전략을 설정.
  - BusinessException 와 ErrorCode 로만 관리할 수도 있지만, 하위 커스텀 예외들로 계층화하는 것이 확장성에 유리할 것이라고 판단. ex) 특정 종류의 예외만 추가적인 로직을 갖게 함.
- GlobalExceptionHandler 에서 기본적인 표준 예외와 BusinessException 처리.