### PR TITLE
Fix: Member 엔티티 수정

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -1,11 +1,8 @@
 CREATE TABLE `member`
 (
     `id`              BIGINT      NOT NULL,
-    `login_id`        VARCHAR(20) NOT NULL,
-    `password`        VARCHAR(20) NOT NULL,
-    `name`            VARCHAR(6)  NOT NULL,
-    `birth`           TIMESTAMP   NOT NULL,
-    `email`           VARCHAR(50) NOT NULL,
+    `login_email`        VARCHAR(50) NOT NULL,
+    `password`        VARCHAR(64) NOT NULL,
     `nickname`        VARCHAR(10) NOT NULL,
     `point`           INT         NOT NULL,
     `created_at`      TIMESTAMP   NOT NULL,
@@ -100,6 +97,12 @@ CREATE TABLE `image`
 
 ALTER TABLE `member`
     ADD CONSTRAINT `PK_MEMBER` PRIMARY KEY (`id`);
+
+ALTER TABLE 'member'
+    ADD CONSTRAINT `UK1_MEMBER` UNIQUE ('login_email');
+
+ALTER TABLE 'member'
+    ADD CONSTRAINT `UK2_MEMBER` UNIQUE ('nickname');
 
 ALTER TABLE `stadium`
     ADD CONSTRAINT `PK_STADIUM` PRIMARY KEY (`id`);

--- a/src/main/java/com/goodseats/seatviewreviews/domain/member/model/entity/Member.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/member/model/entity/Member.java
@@ -25,20 +25,11 @@ public class Member extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "login_id", length = 20, nullable = false)
-	private String loginId;
+	@Column(name = "login_email", length = 50, nullable = false, unique = true)
+	private String loginEmail;
 
-	@Column(name = "password", length = 20, nullable = false)
+	@Column(name = "password", length = 64, nullable = false)
 	private String password;
-
-	@Column(name = "name", length = 6, nullable = false)
-	private String name;
-
-	@Column(name = "birth", nullable = false)
-	private LocalDate birth;
-
-	@Column(name = "email", length = 50, nullable = false, unique = true)
-	private String email;
 
 	@Column(name = "nickname", length = 10, nullable = false, unique = true)
 	private String nickname;
@@ -46,12 +37,9 @@ public class Member extends BaseEntity {
 	@Column(name = "point", nullable = false)
 	private int point;
 
-	public Member(String loginId, String password, String name, LocalDate birth, String email, String nickname) {
-		this.loginId = loginId;
+	public Member(String loginEmail, String password, String nickname) {
+		this.loginEmail = loginEmail;
 		this.password = password;
-		this.name = name;
-		this.birth = birth;
-		this.email = email;
 		this.nickname = nickname;
 		this.point = 0;
 	}


### PR DESCRIPTION
### 관련 이슈
- close #11 

### 내용
- 로그인 아이디로 이메일을 사용하게 함
  - 필드 명 loginEmail 로 수정
  - 최대 길이 50 으로 수정
- 불필요한 필드들 삭제 (이름, 생년월일, 이메일)
- 비밀번호를 SHA-256 알고리즘으로 암호화하여서 저장하기에 길이 64 로 수정
- init.sql 수정