### PR TITLE
Fix: Member 테이블의 비밀번호 컬럼의 최대 길이 수정

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -2,7 +2,7 @@ CREATE TABLE `member`
 (
     `id`              BIGINT AUTO_INCREMENT PRIMARY KEY,
     `login_email`     VARCHAR(50) NOT NULL UNIQUE,
-    `password`        VARCHAR(64) NOT NULL,
+    `password`        VARCHAR(255) NOT NULL,
     `nickname`        VARCHAR(10) NOT NULL UNIQUE,
     `point`           INT         NOT NULL,
     `created_at`      TIMESTAMP   NOT NULL,

--- a/src/main/java/com/goodseats/seatviewreviews/domain/member/model/entity/Member.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/member/model/entity/Member.java
@@ -1,7 +1,5 @@
 package com.goodseats.seatviewreviews.domain.member.model.entity;
 
-import java.time.LocalDate;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -28,7 +26,7 @@ public class Member extends BaseEntity {
 	@Column(name = "login_email", length = 50, nullable = false, unique = true)
 	private String loginEmail;
 
-	@Column(name = "password", length = 64, nullable = false)
+	@Column(name = "password", length = 255, nullable = false)
 	private String password;
 
 	@Column(name = "nickname", length = 10, nullable = false, unique = true)


### PR DESCRIPTION
### 관련 이슈
- close #16 

### 내용
- 현재 64로 되어있는데 암호화 알고리즘에 따라 길이는 달라질 수 있으니 255로 늘림