### PR TITLE
Feat: 로그인 기능 구현

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/common/config/WebConfig.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.goodseats.seatviewreviews.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.goodseats.seatviewreviews.common.security.AuthenticationInterceptor;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(new AuthenticationInterceptor());
+	}
+}

--- a/src/main/java/com/goodseats/seatviewreviews/common/error/exception/AuthenticationException.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/exception/AuthenticationException.java
@@ -1,0 +1,12 @@
+package com.goodseats.seatviewreviews.common.error.exception;
+
+public class AuthenticationException extends BusinessException{
+
+	public AuthenticationException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public AuthenticationException(ErrorCode errorCode, Throwable cause) {
+		super(errorCode, cause);
+	}
+}

--- a/src/main/java/com/goodseats/seatviewreviews/common/error/exception/ErrorCode.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/exception/ErrorCode.java
@@ -8,7 +8,8 @@ public enum ErrorCode {
 	NOT_FOUND(404, "존재하지 않는 데이터입니다."),
 	DUPLICATED_ID(409, "중복된 아이디입니다."),
 	DUPLICATED_NICKNAME(409, "중복된 닉네임입니다."),
-	UNAUTHORIZED(401, "인증되지 않은 사용자입니다.");
+	UNAUTHORIZED(401, "인증되지 않은 사용자입니다."),
+	BAD_LOGIN_REQUEST(400, "아이디 혹은 비밀번호가 틀립니다.");
 
 	private final int status;
 	private final String message;

--- a/src/main/java/com/goodseats/seatviewreviews/common/error/exception/ErrorCode.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/exception/ErrorCode.java
@@ -7,7 +7,8 @@ public enum ErrorCode {
 
 	NOT_FOUND(404, "존재하지 않는 데이터입니다."),
 	DUPLICATED_ID(409, "중복된 아이디입니다."),
-	DUPLICATED_NICKNAME(409, "중복된 닉네임입니다.");
+	DUPLICATED_NICKNAME(409, "중복된 닉네임입니다."),
+	UNAUTHORIZED(401, "인증되지 않은 사용자입니다.");
 
 	private final int status;
 	private final String message;

--- a/src/main/java/com/goodseats/seatviewreviews/common/security/AuthenticationInterceptor.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/security/AuthenticationInterceptor.java
@@ -1,0 +1,50 @@
+package com.goodseats.seatviewreviews.common.security;
+
+import static com.goodseats.seatviewreviews.common.error.exception.ErrorCode.*;
+import static com.goodseats.seatviewreviews.common.security.SessionConstant.*;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.goodseats.seatviewreviews.common.error.exception.AuthenticationException;
+import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
+
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+
+		HandlerMethod handlerMethod = (HandlerMethod)handler;
+		Authority authorityAnnotation = handlerMethod.getMethodAnnotation(Authority.class);
+
+		if (Objects.isNull(authorityAnnotation)) {
+			return true;
+		}
+
+		HttpSession session = request.getSession(false);
+		AuthenticationDTO authenticationDTO = (AuthenticationDTO)session.getAttribute(LOGIN_MEMBER_INFO);
+
+		if (Objects.isNull(authenticationDTO)) {
+			throw new AuthenticationException(UNAUTHORIZED);
+		}
+
+		return checkAuthority(authorityAnnotation, authenticationDTO);
+	}
+
+	private boolean checkAuthority(Authority authorityAnnotation, AuthenticationDTO authenticationDTO) {
+		boolean hasAuthority = Arrays.stream(authorityAnnotation.authorities())
+				.anyMatch(authority -> authority.equals(authenticationDTO.memberAuthority()));
+
+		if (hasAuthority) {
+			return true;
+		}
+		throw new AuthenticationException(UNAUTHORIZED);
+	}
+}

--- a/src/main/java/com/goodseats/seatviewreviews/common/security/Authority.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/security/Authority.java
@@ -1,0 +1,17 @@
+package com.goodseats.seatviewreviews.common.security;
+
+import static com.goodseats.seatviewreviews.domain.member.model.vo.MemberAuthority.*;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.goodseats.seatviewreviews.domain.member.model.vo.MemberAuthority;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authority {
+
+	MemberAuthority[] authorities() default {USER, ADMIN};
+}

--- a/src/main/java/com/goodseats/seatviewreviews/common/security/SessionConstant.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/security/SessionConstant.java
@@ -1,0 +1,10 @@
+package com.goodseats.seatviewreviews.common.security;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SessionConstant {
+
+	public static final String LOGIN_MEMBER_INFO = "loginMemberInfo";
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/member/controller/MemberController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/member/controller/MemberController.java
@@ -1,5 +1,7 @@
 package com.goodseats.seatviewreviews.domain.member.controller;
 
+import static com.goodseats.seatviewreviews.common.security.SessionConstant.*;
+
 import java.net.URI;
 
 import javax.servlet.http.HttpServletRequest;
@@ -25,7 +27,6 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/members")
 public class MemberController {
 
-	private static final String LOGIN_MEMBER_INFO = "loginMemberInfo";
 	private final MemberService memberService;
 
 	@PostMapping(consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)

--- a/src/main/java/com/goodseats/seatviewreviews/domain/member/controller/MemberController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.goodseats.seatviewreviews.domain.member.controller;
 import java.net.URI;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
 import org.springframework.http.MediaType;
@@ -12,6 +13,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
+import com.goodseats.seatviewreviews.domain.member.model.dto.MemberLoginRequest;
 import com.goodseats.seatviewreviews.domain.member.model.dto.MemberSignUpRequest;
 import com.goodseats.seatviewreviews.domain.member.service.MemberService;
 
@@ -22,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/members")
 public class MemberController {
 
+	private static final String LOGIN_MEMBER_INFO = "loginMemberInfo";
 	private final MemberService memberService;
 
 	@PostMapping(consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
@@ -34,6 +38,19 @@ public class MemberController {
 		return ResponseEntity
 				.created(URI.create(request.getRequestURI() + "/" + savedMemberId))
 				.build();
+	}
+
+	@PostMapping(value = "/login", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+	public ResponseEntity<Void> login(
+			@Valid @ModelAttribute MemberLoginRequest memberLoginRequest,
+			HttpServletRequest request
+	) {
+		AuthenticationDTO authenticationDto = memberService.login(memberLoginRequest);
+
+		HttpSession session = request.getSession(true);
+		session.setAttribute(LOGIN_MEMBER_INFO, authenticationDto);
+
+		return ResponseEntity.noContent().build();
 	}
 }
 

--- a/src/main/java/com/goodseats/seatviewreviews/domain/member/model/dto/AuthenticationDTO.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/member/model/dto/AuthenticationDTO.java
@@ -1,0 +1,6 @@
+package com.goodseats.seatviewreviews.domain.member.model.dto;
+
+import com.goodseats.seatviewreviews.domain.member.model.vo.MemberAuthority;
+
+public record AuthenticationDTO(Long memberId, MemberAuthority memberAuthority) {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/member/model/dto/MemberLoginRequest.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/member/model/dto/MemberLoginRequest.java
@@ -1,0 +1,9 @@
+package com.goodseats.seatviewreviews.domain.member.model.dto;
+
+import javax.validation.constraints.NotBlank;
+
+public record MemberLoginRequest(
+		@NotBlank String loginEmail,
+		@NotBlank String password
+) {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/member/repository/MemberRepository.java
@@ -1,5 +1,7 @@
 package com.goodseats.seatviewreviews.domain.member.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
@@ -7,6 +9,8 @@ import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	boolean existsByLoginEmail(String email);
+
+	Optional<Member> findByLoginEmail(String email);
 
 	boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/member/service/BCryptPasswordEncoder.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/member/service/BCryptPasswordEncoder.java
@@ -10,4 +10,9 @@ public class BCryptPasswordEncoder implements PasswordEncoder{
 	public String encode(String password) {
 		return BCrypt.hashpw(password, BCrypt.gensalt());
 	}
+
+	@Override
+	public boolean isMatch(String password, String encodedPassword) {
+		return BCrypt.checkpw(password, encodedPassword);
+	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/member/service/MemberService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/member/service/MemberService.java
@@ -36,7 +36,7 @@ public class MemberService {
 		return memberRepository.findByLoginEmail(memberLoginRequest.loginEmail())
 				.filter(member -> passwordEncoder.isMatch(memberLoginRequest.password(), member.getPassword()))
 				.map(member -> new AuthenticationDTO(member.getId(), member.getMemberAuthority()))
-				.orElseThrow(() -> new AuthenticationException(UNAUTHORIZED));
+				.orElseThrow(() -> new AuthenticationException(BAD_LOGIN_REQUEST));
 	}
 
 	private void validateDuplicateEmail(String loginEmail) {

--- a/src/main/java/com/goodseats/seatviewreviews/domain/member/service/MemberService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/member/service/MemberService.java
@@ -1,10 +1,14 @@
 package com.goodseats.seatviewreviews.domain.member.service;
 
+import static com.goodseats.seatviewreviews.common.error.exception.ErrorCode.*;
+
 import org.springframework.stereotype.Service;
 
+import com.goodseats.seatviewreviews.common.error.exception.AuthenticationException;
 import com.goodseats.seatviewreviews.common.error.exception.DuplicatedException;
-import com.goodseats.seatviewreviews.common.error.exception.ErrorCode;
 import com.goodseats.seatviewreviews.domain.member.mapper.MemberMapper;
+import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
+import com.goodseats.seatviewreviews.domain.member.model.dto.MemberLoginRequest;
 import com.goodseats.seatviewreviews.domain.member.model.dto.MemberSignUpRequest;
 import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
 import com.goodseats.seatviewreviews.domain.member.repository.MemberRepository;
@@ -28,15 +32,22 @@ public class MemberService {
 		return savedMember.getId();
 	}
 
+	public AuthenticationDTO login(MemberLoginRequest memberLoginRequest) {
+		return memberRepository.findByLoginEmail(memberLoginRequest.loginEmail())
+				.filter(member -> passwordEncoder.isMatch(memberLoginRequest.password(), member.getPassword()))
+				.map(member -> new AuthenticationDTO(member.getId(), member.getMemberAuthority()))
+				.orElseThrow(() -> new AuthenticationException(UNAUTHORIZED));
+	}
+
 	private void validateDuplicateEmail(String loginEmail) {
 		if (memberRepository.existsByLoginEmail(loginEmail)) {
-			throw new DuplicatedException(ErrorCode.DUPLICATED_ID);
+			throw new DuplicatedException(DUPLICATED_ID);
 		}
 	}
 
 	private void validateDuplicateNickname(String nickname) {
 		if (memberRepository.existsByNickname(nickname)) {
-			throw new DuplicatedException(ErrorCode.DUPLICATED_NICKNAME);
+			throw new DuplicatedException(DUPLICATED_NICKNAME);
 		}
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/member/service/PasswordEncoder.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/member/service/PasswordEncoder.java
@@ -3,4 +3,6 @@ package com.goodseats.seatviewreviews.domain.member.service;
 public interface PasswordEncoder {
 
 	String encode(String password);
+
+	boolean isMatch(String password, String encodedPassword);
 }

--- a/src/test/java/com/goodseats/seatviewreviews/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/member/service/MemberServiceTest.java
@@ -151,7 +151,7 @@ class MemberServiceTest {
 			// when & then
 			assertThatThrownBy(() -> memberService.login(loginRequest))
 					.isExactlyInstanceOf(AuthenticationException.class)
-					.hasMessage(UNAUTHORIZED.getMessage());
+					.hasMessage(BAD_LOGIN_REQUEST.getMessage());
 			verify(memberRepository).findByLoginEmail(loginRequest.loginEmail());
 		}
 
@@ -167,7 +167,7 @@ class MemberServiceTest {
 			// when & then
 			assertThatThrownBy(() -> memberService.login(loginRequest))
 					.isExactlyInstanceOf(AuthenticationException.class)
-					.hasMessage(UNAUTHORIZED.getMessage());
+					.hasMessage(BAD_LOGIN_REQUEST.getMessage());
 			verify(memberRepository).findByLoginEmail(loginRequest.loginEmail());
 			verify(savedMember).getPassword();
 			verify(passwordEncoder).isMatch(loginRequest.password(), wrongPassword);

--- a/src/test/java/com/goodseats/seatviewreviews/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/member/service/MemberServiceTest.java
@@ -4,6 +4,8 @@ import static com.goodseats.seatviewreviews.common.error.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,9 +15,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.goodseats.seatviewreviews.common.error.exception.AuthenticationException;
 import com.goodseats.seatviewreviews.common.error.exception.DuplicatedException;
+import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
+import com.goodseats.seatviewreviews.domain.member.model.dto.MemberLoginRequest;
 import com.goodseats.seatviewreviews.domain.member.model.dto.MemberSignUpRequest;
 import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
+import com.goodseats.seatviewreviews.domain.member.model.vo.MemberAuthority;
 import com.goodseats.seatviewreviews.domain.member.repository.MemberRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,12 +45,18 @@ class MemberServiceTest {
 			"Jerome"
 	);
 
+	private MemberLoginRequest loginRequest = new MemberLoginRequest(
+			memberSignUpRequest.loginEmail(),
+			memberSignUpRequest.password()
+	);
+
+	private String encodedPassword = BCrypt.hashpw(memberSignUpRequest.password(), BCrypt.gensalt());
+	private Long memberId = 1L;
+
 	@Test
 	@DisplayName("Success - 회원가입에 성공한다")
 	void signUpSuccess() {
 		// given
-		String encodedPassword = BCrypt.hashpw("password", BCrypt.gensalt());
-		Long memberId = 1L;
 		when(memberRepository.existsByLoginEmail(memberSignUpRequest.loginEmail())).thenReturn(false);
 		when(memberRepository.existsByNickname(memberSignUpRequest.nickname())).thenReturn(false);
 		when(passwordEncoder.encode(memberSignUpRequest.password())).thenReturn(encodedPassword);
@@ -100,6 +112,65 @@ class MemberServiceTest {
 			verify(passwordEncoder, times(0)).encode(memberSignUpRequest.password());
 			verify(memberRepository, times(0)).save(any(Member.class));
 			verify(savedMember, times(0)).getId();
+		}
+	}
+
+	@Test
+	@DisplayName("Success - 로그인에 성공한다.")
+	void loginSuccess() {
+		// given
+		when(memberRepository.findByLoginEmail(loginRequest.loginEmail())).thenReturn(Optional.of(savedMember));
+		when(savedMember.getPassword()).thenReturn(encodedPassword);
+		when(passwordEncoder.isMatch(loginRequest.password(), encodedPassword)).thenReturn(true);
+		when(savedMember.getId()).thenReturn(memberId);
+		when(savedMember.getMemberAuthority()).thenReturn(MemberAuthority.USER);
+
+		// when
+		AuthenticationDTO authenticationDTO = memberService.login(loginRequest);
+
+		// then
+		verify(memberRepository).findByLoginEmail(loginRequest.loginEmail());
+		verify(savedMember).getPassword();
+		verify(passwordEncoder).isMatch(loginRequest.password(), encodedPassword);
+		verify(savedMember).getId();
+		verify(savedMember).getMemberAuthority();
+		assertThat(authenticationDTO.memberId()).isEqualTo(memberId);
+		assertThat(authenticationDTO.memberAuthority()).isEqualTo(MemberAuthority.USER);
+	}
+
+	@Nested
+	@DisplayName("loginFail")
+	class LoginFail {
+
+		@Test
+		@DisplayName("Fail - 잘못된 아이디를 입력하여 로그인에 실패한다.")
+		void loginFailByWrongLoginEmail() {
+			// given
+			when(memberRepository.findByLoginEmail(loginRequest.loginEmail())).thenReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> memberService.login(loginRequest))
+					.isExactlyInstanceOf(AuthenticationException.class)
+					.hasMessage(UNAUTHORIZED.getMessage());
+			verify(memberRepository).findByLoginEmail(loginRequest.loginEmail());
+		}
+
+		@Test
+		@DisplayName("Fail - 잘못된 비밀번호를 입력하여 로그인에 실패한다.")
+		void loginFailByWrongPassword() {
+			// given
+			String wrongPassword = "wrongPassword";
+			when(memberRepository.findByLoginEmail(loginRequest.loginEmail())).thenReturn(Optional.of(savedMember));
+			when(savedMember.getPassword()).thenReturn(wrongPassword);
+			when(passwordEncoder.isMatch(loginRequest.password(), wrongPassword)).thenReturn(false);
+
+			// when & then
+			assertThatThrownBy(() -> memberService.login(loginRequest))
+					.isExactlyInstanceOf(AuthenticationException.class)
+					.hasMessage(UNAUTHORIZED.getMessage());
+			verify(memberRepository).findByLoginEmail(loginRequest.loginEmail());
+			verify(savedMember).getPassword();
+			verify(passwordEncoder).isMatch(loginRequest.password(), wrongPassword);
 		}
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #28 
- close #10 

### 내용
- PasswordEncoder 에 isMatch 메서드 추가
  - 입력 비밀번호와 암호화된 비밀번호가 매칭되는지 확인하는 메서드임
- 인증 실패 시 발생하는 예외 클래스와 예외 코드 추가
  - AuthenticationException 와 ErrorCode.UNAUTHORIZED
- 로그인 요청 DTO 구현 (MemberLoginRequest)
- 로그인 성공 시 세션에 담을 인증 객체 구현 (AuthenticationDTO)
- 로그인 기능 구현
- API 별 권한을 명시하는 커스텀 어노테이션 추가 (@Authority)
- API 호출 시 명시된 권한에 부합하는 지 체크하는 인터셉터 추가 (AuthenticationInterceptor)
- 로그인 기능 서비스단 테스트 작성
- 로그인 기능 통합테스트 작성