### PR TITLE
Style: Team Enum 클래스 수정

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/domain/stadium/model/entity/Stadium.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/stadium/model/entity/Stadium.java
@@ -10,7 +10,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 import com.goodseats.seatviewreviews.domain.BaseEntity;
-import com.goodseats.seatviewreviews.domain.stadium.model.vo.Team;
+import com.goodseats.seatviewreviews.domain.stadium.model.vo.HomeTeam;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -34,9 +34,9 @@ public class Stadium extends BaseEntity {
 
 	@Column(name = "home_team", length = 50, nullable = false)
 	@Enumerated(value = EnumType.STRING)
-	private Team homeTeam;
+	private HomeTeam homeTeam;
 
-	public Stadium(String name, String address, Team homeTeam) {
+	public Stadium(String name, String address, HomeTeam homeTeam) {
 		this.name = name;
 		this.address = address;
 		this.homeTeam = homeTeam;

--- a/src/main/java/com/goodseats/seatviewreviews/domain/stadium/model/vo/HomeTeam.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/stadium/model/vo/HomeTeam.java
@@ -1,12 +1,11 @@
 package com.goodseats.seatviewreviews.domain.stadium.model.vo;
 
-public enum Team {
-	DOOSAN,
+public enum HomeTeam {
+	DOOSAN_LG,
 	HANWHA,
 	KIA,
 	KIWOOM,
 	KT,
-	LG,
 	LOTTE,
 	NC,
 	SAMSUNG,


### PR DESCRIPTION
### 관련 이슈
- close #35 

### 내용
- 클래스 명 Team -> HomeTeam 으로 수정
  - 야구장의 홈 팀에 대한 정보를 나타내므로 더 명확하게 수정함
- DOOSAN, LG 를 DOOSAN_LG 로 합침
  - 잠실 야구장의 경우 두산과 LG 가 함께 사용하기 때문