### PR TITLE
Add: 야구장 관련 데이터 DML 파일 추가

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,7 +11,9 @@ services:
       TZ: Asia/Seoul
     volumes:
       - seat-view:/var/lib/seat-view/db
+      - ./my.cnf:/etc/mysql/my.cnf
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./stadium.sql:/docker-entrypoint-initdb.d/stadium.sql
     restart: always
 
 volumes:

--- a/docker/my.cnf
+++ b/docker/my.cnf
@@ -1,0 +1,9 @@
+[client]
+default-character-set=utf8mb4
+
+[mysql]
+default-character-set=utf8mb4
+
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci

--- a/docker/stadium.sql
+++ b/docker/stadium.sql
@@ -1,0 +1,26 @@
+INSERT INTO stadium (name, address, home_team, created_at, deleted_at, last_updated_at)
+VALUES ('잠실 야구장', '서울 송파구 올림픽로 19-2 서울종합운동장', 'DOOSAN_LG', NOW(), null, NOW());
+
+INSERT INTO stadium (name, address, home_team, created_at, deleted_at, last_updated_at)
+VALUES ('한화생명 이글스 파크', '대전 중구 대종로 373', 'HANWHA', NOW(), null, NOW());
+
+INSERT INTO stadium (name, address, home_team, created_at, deleted_at, last_updated_at)
+VALUES ('광주 기아 챔피언스 필드', '광주 북구 서림로 10 무등종합경기장', 'KIA', NOW(), null, NOW());
+
+INSERT INTO stadium (name, address, home_team, created_at, deleted_at, last_updated_at)
+VALUES ('고척 스카이돔', '서울 구로구 경인로 430 고척스카이돔', 'KIWOOM', NOW(), null, NOW());
+
+INSERT INTO stadium (name, address, home_team, created_at, deleted_at, last_updated_at)
+VALUES ('수원KT위즈파크', '경기 수원시 장안구 경수대로 893 수원종합운동장(주경기장)', 'KT', NOW(), null, NOW());
+
+INSERT INTO stadium (name, address, home_team, created_at, deleted_at, last_updated_at)
+VALUES ('사직 야구장', '부산 동래구 사직로 45', 'LOTTE', NOW(), null, NOW());
+
+INSERT INTO stadium (name, address, home_team, created_at, deleted_at, last_updated_at)
+VALUES ('창원NC파크', '경남 창원시 마산회원구 삼호로 63', 'NC', NOW(), null, NOW());
+
+INSERT INTO stadium (name, address, home_team, created_at, deleted_at, last_updated_at)
+VALUES ('대구 삼성 라이온즈 파크', '대구 수성구 야구전설로 1 대구삼성라이온즈파크', 'SAMSUNG', NOW(), null, NOW());
+
+INSERT INTO stadium (name, address, home_team, created_at, deleted_at, last_updated_at)
+VALUES ('인천SSG 랜더스필드', '인천 미추홀구 매소홀로 618', 'SSG', NOW(), null, NOW());


### PR DESCRIPTION
### 관련 이슈
- close #30 

### 내용
- MySQL 설정 파일 추가
  - 도커에서 실행되는 MySQL 의 클라이언트 캐릭터 셋을 utf8mb4 로 지정해주기 위해서
- 야구장 관련 데이터 DML 파일 추가