### PR TITLE
Refactor: 좌석 테이블 분리

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -22,13 +22,33 @@ CREATE TABLE `stadium`
     `deleted_at`      TIMESTAMP    NULL
 );
 
+CREATE TABLE `seat_grade`
+(
+    `id`              BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `stadium_id`      BIGINT       NOT NULL,
+    `name`            VARCHAR(30)  NOT NULL,
+    `price_info`      VARCHAR(100) NOT NULL,
+    `created_at`      TIMESTAMP    NOT NULL,
+    `last_updated_at` TIMESTAMP    NOT NULL,
+    `deleted_at`      TIMESTAMP    NULL
+);
+
+CREATE TABLE `seat_section`
+(
+    `id`              BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `seat_grade_id`   BIGINT      NOT NULL,
+    `name`            VARCHAR(50) NOT NULL,
+    `created_at`      TIMESTAMP   NOT NULL,
+    `last_updated_at` TIMESTAMP   NOT NULL,
+    `deleted_at`      TIMESTAMP   NULL
+);
+
 CREATE TABLE `seat`
 (
     `id`              BIGINT AUTO_INCREMENT PRIMARY KEY,
-    `stadium_id`      BIGINT      NOT NULL,
-    `section`         VARCHAR(10) NOT NULL,
-    `price`           INT         NOT NULL,
-    `seat_number`     INT         NOT NULL,
+    `seat_grade_id`      BIGINT      NOT NULL,
+    `seat_section_id`    BIGINT      NOT NULL,
+    `seat_info`       VARCHAR(10) NOT NULL,
     `average_score`   DECIMAL     NOT NULL,
     `created_at`      TIMESTAMP   NOT NULL,
     `last_updated_at` TIMESTAMP   NOT NULL,

--- a/src/main/java/com/goodseats/seatviewreviews/domain/seat/model/entity/SeatGrade.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/seat/model/entity/SeatGrade.java
@@ -11,39 +11,35 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import com.goodseats.seatviewreviews.domain.BaseEntity;
+import com.goodseats.seatviewreviews.domain.stadium.model.entity.Stadium;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "seat")
+@Table(name = "seat_grade")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Seat extends BaseEntity {
+public class SeatGrade extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "seat_info", length = 10, nullable = false)
-	private String seatInfo;
+	@Column(name = "name", length = 30, nullable = false)
+	private String name;
 
-	@Column(name = "average_score", nullable = false)
-	private float averageScore;
-
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "seat_grade_id")
-	private SeatGrade seatGrade;
+	@Column(name = "price_info")
+	private String priceInfo;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "seat_section_id")
-	private SeatSection seatSection;
+	@JoinColumn(name = "stadium_id")
+	private Stadium stadium;
 
-	public Seat(String seatInfo, SeatGrade seatGrade, SeatSection seatSection) {
-		this.seatInfo = seatInfo;
-		this.averageScore = 0;
-		this.seatGrade = seatGrade;
-		this.seatSection = seatSection;
+	public SeatGrade(String name, String priceInfo, Stadium stadium) {
+		this.name = name;
+		this.priceInfo = priceInfo;
+		this.stadium = stadium;
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/seat/model/entity/SeatSection.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/seat/model/entity/SeatSection.java
@@ -17,33 +17,24 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "seat")
+@Table(name = "seat_section")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Seat extends BaseEntity {
+public class SeatSection extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "seat_info", length = 10, nullable = false)
-	private String seatInfo;
-
-	@Column(name = "average_score", nullable = false)
-	private float averageScore;
+	@Column(name = "name", length = 10, nullable = false)
+	private String name;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "seat_grade_id")
 	private SeatGrade seatGrade;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "seat_section_id")
-	private SeatSection seatSection;
-
-	public Seat(String seatInfo, SeatGrade seatGrade, SeatSection seatSection) {
-		this.seatInfo = seatInfo;
-		this.averageScore = 0;
+	public SeatSection(String name, SeatGrade seatGrade) {
+		this.name = name;
 		this.seatGrade = seatGrade;
-		this.seatSection = seatSection;
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #39 

### 내용
- 좌석 테이블이 가지고 있던 좌석 구역을 테이블로 분리함
  - 한 경기장에 20-30 여개의 좌석 구역이 존재하고, 하나의 구역이 100개 가량의 좌석을 가지므로, 좌석 테이블에서 2000개 가량의 좌석 구역 컬럼이 중복
  - 현재는 분리한 좌석 구역 테이블의 컬럼이 "name" 한 개 뿐이라 큰 효과가 없을 수 있지만, 서비스 특성 상 좌석 구역 별로 정보를 제공하는 것이 많을 것이므로 확장성에 유리함
- 좌석 등급 테이블을 추가하고, 좌석 테이블이 가지던 "price" 컬럼을 좌석 등급 테이블로 옮김
- 좌석 엔티티 생성자에서 평균 평점 기본 값 0으로 지정
- 좌석 엔티티의 "seatNumber" 필드를 "seatInfo" 로 바꾸고 자료형도 String 으로 변경
  - 좌석 번호가 A1 인 경우에 대응하기 위함
- 좌석 테이블 수정에 따른 init.sql 수정