### PR TITLE
Feat: 경기장 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/domain/stadium/controller/StadiumController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/stadium/controller/StadiumController.java
@@ -1,0 +1,25 @@
+package com.goodseats.seatviewreviews.domain.stadium.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumsResponse;
+import com.goodseats.seatviewreviews.domain.stadium.service.StadiumService;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stadiums")
+public class StadiumController {
+
+	private final StadiumService stadiumService;
+
+	@GetMapping
+	public ResponseEntity<StadiumsResponse> getStadiums() {
+		StadiumsResponse stadiumsResponse = stadiumService.getStadiums();
+		return ResponseEntity.ok(stadiumsResponse);
+	}
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/stadium/controller/StadiumController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/stadium/controller/StadiumController.java
@@ -1,5 +1,6 @@
 package com.goodseats.seatviewreviews.domain.stadium.controller;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,7 +18,7 @@ public class StadiumController {
 
 	private final StadiumService stadiumService;
 
-	@GetMapping
+	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<StadiumsResponse> getStadiums() {
 		StadiumsResponse stadiumsResponse = stadiumService.getStadiums();
 		return ResponseEntity.ok(stadiumsResponse);

--- a/src/main/java/com/goodseats/seatviewreviews/domain/stadium/mapper/StadiumMapper.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/stadium/mapper/StadiumMapper.java
@@ -1,0 +1,15 @@
+package com.goodseats.seatviewreviews.domain.stadium.mapper;
+
+import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumsElementResponse;
+import com.goodseats.seatviewreviews.domain.stadium.model.entity.Stadium;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class StadiumMapper {
+
+	public static StadiumsElementResponse toStadiumsElementResponse(Stadium stadium) {
+		return new StadiumsElementResponse(stadium.getId(), stadium.getName(), stadium.getHomeTeam());
+	}
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/stadium/model/dto/StadiumsElementResponse.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/stadium/model/dto/StadiumsElementResponse.java
@@ -1,0 +1,6 @@
+package com.goodseats.seatviewreviews.domain.stadium.model.dto;
+
+import com.goodseats.seatviewreviews.domain.stadium.model.vo.HomeTeam;
+
+public record StadiumsElementResponse(Long stadiumId, String name, HomeTeam homeTeam) {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/stadium/model/dto/StadiumsResponse.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/stadium/model/dto/StadiumsResponse.java
@@ -1,0 +1,6 @@
+package com.goodseats.seatviewreviews.domain.stadium.model.dto;
+
+import java.util.List;
+
+public record StadiumsResponse(List<StadiumsElementResponse> stadiums) {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/stadium/repository/StadiumRepository.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/stadium/repository/StadiumRepository.java
@@ -1,0 +1,8 @@
+package com.goodseats.seatviewreviews.domain.stadium.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goodseats.seatviewreviews.domain.stadium.model.entity.Stadium;
+
+public interface StadiumRepository extends JpaRepository<Stadium, Long> {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/stadium/service/StadiumService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/stadium/service/StadiumService.java
@@ -1,0 +1,30 @@
+package com.goodseats.seatviewreviews.domain.stadium.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goodseats.seatviewreviews.domain.stadium.mapper.StadiumMapper;
+import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumsElementResponse;
+import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumsResponse;
+import com.goodseats.seatviewreviews.domain.stadium.repository.StadiumRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class StadiumService {
+
+	private final StadiumRepository stadiumRepository;
+
+	@Transactional(readOnly = true)
+	public StadiumsResponse getStadiums() {
+		List<StadiumsElementResponse> elementResponses = stadiumRepository.findAll()
+				.stream()
+				.map(StadiumMapper::toStadiumsElementResponse)
+				.toList();
+
+		return new StadiumsResponse(elementResponses);
+	}
+}

--- a/src/test/java/com/goodseats/seatviewreviews/domain/stadium/controller/StadiumControllerTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/stadium/controller/StadiumControllerTest.java
@@ -1,0 +1,63 @@
+package com.goodseats.seatviewreviews.domain.stadium.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goodseats.seatviewreviews.domain.stadium.mapper.StadiumMapper;
+import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumsElementResponse;
+import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumsResponse;
+import com.goodseats.seatviewreviews.domain.stadium.model.entity.Stadium;
+import com.goodseats.seatviewreviews.domain.stadium.model.vo.HomeTeam;
+import com.goodseats.seatviewreviews.domain.stadium.repository.StadiumRepository;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+class StadiumControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private StadiumRepository stadiumRepository;
+
+	@Test
+	@DisplayName("Success - 경기장 목록 조회에 성공하고 200 으로 응답한다")
+	void getStadiumsSuccess() throws Exception {
+		// given
+		Stadium jamsil = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
+		Stadium hanwha = new Stadium("한화생명 이글스 파크", "대전 중구 대종로 373", HomeTeam.HANWHA);
+		List<Stadium> stadiums = List.of(jamsil, hanwha);
+		stadiumRepository.saveAll(stadiums);
+
+		List<StadiumsElementResponse> stadiumsElementResponses = stadiumRepository.findAll().stream()
+				.map(StadiumMapper::toStadiumsElementResponse)
+				.toList();
+		StadiumsResponse stadiumsResponse = new StadiumsResponse(stadiumsElementResponses);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/stadiums")
+						.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(content().json(objectMapper.writeValueAsString(stadiumsResponse)))
+				.andDo(print())
+				.andReturn();
+	}
+}

--- a/src/test/java/com/goodseats/seatviewreviews/domain/stadium/service/StadiumServiceTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/stadium/service/StadiumServiceTest.java
@@ -30,8 +30,8 @@ class StadiumServiceTest {
 	@DisplayName("Success - 경기장 목록 조회에 성공한다")
 	void getStadiumsSuccess() {
 		// given
-		Stadium jamsil = new Stadium("잠실 야구장", "testAddress", HomeTeam.DOOSAN_LG);
-		Stadium hanwha = new Stadium("한화생명 이글스 파크", "testAddress", HomeTeam.HANWHA);
+		Stadium jamsil = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
+		Stadium hanwha = new Stadium("한화생명 이글스 파크", "대전 중구 대종로 373", HomeTeam.HANWHA);
 		List<Stadium> stadiums = List.of(jamsil, hanwha);
 		when(stadiumRepository.findAll()).thenReturn(stadiums);
 

--- a/src/test/java/com/goodseats/seatviewreviews/domain/stadium/service/StadiumServiceTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/stadium/service/StadiumServiceTest.java
@@ -1,0 +1,51 @@
+package com.goodseats.seatviewreviews.domain.stadium.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumsResponse;
+import com.goodseats.seatviewreviews.domain.stadium.model.entity.Stadium;
+import com.goodseats.seatviewreviews.domain.stadium.model.vo.HomeTeam;
+import com.goodseats.seatviewreviews.domain.stadium.repository.StadiumRepository;
+
+@ExtendWith(MockitoExtension.class)
+class StadiumServiceTest {
+
+	@Mock
+	private StadiumRepository stadiumRepository;
+
+	@InjectMocks
+	private StadiumService stadiumService;
+
+	@Test
+	@DisplayName("Success - 경기장 목록 조회에 성공한다")
+	void getStadiumsSuccess() {
+		// given
+		Stadium jamsil = new Stadium("잠실 야구장", "testAddress", HomeTeam.DOOSAN_LG);
+		Stadium hanwha = new Stadium("한화생명 이글스 파크", "testAddress", HomeTeam.HANWHA);
+		List<Stadium> stadiums = List.of(jamsil, hanwha);
+		when(stadiumRepository.findAll()).thenReturn(stadiums);
+
+		// when
+		StadiumsResponse stadiumsResponse = stadiumService.getStadiums();
+
+		// then
+		verify(stadiumRepository).findAll();
+		assertThat(stadiumsResponse.stadiums().size()).isEqualTo(stadiums.size());
+
+		for (int i = 0; i < stadiums.size(); i++) {
+			assertThat(stadiumsResponse.stadiums().get(i)).usingRecursiveComparison()
+					.ignoringFields("stadiumId")
+					.isEqualTo(stadiums.get(i));
+		}
+	}
+}


### PR DESCRIPTION
### 관련 이슈
- close #31 

### 내용
- 야구장 목록 응답을 위한 DTO 추가
- Stadium 관련 DTO 와 엔티티 사이 변환을 위한 mapper 추가
- 야구장 목록 조회 API 구현
- 야구장 목록 조회 API 테스트 코드 작성