### PR TITLE
Feat: 경기장 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/domain/stadium/controller/StadiumController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/stadium/controller/StadiumController.java
@@ -4,8 +4,10 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumDetailResponse;
 import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumsResponse;
 import com.goodseats.seatviewreviews.domain.stadium.service.StadiumService;
 
@@ -22,5 +24,11 @@ public class StadiumController {
 	public ResponseEntity<StadiumsResponse> getStadiums() {
 		StadiumsResponse stadiumsResponse = stadiumService.getStadiums();
 		return ResponseEntity.ok(stadiumsResponse);
+	}
+
+	@GetMapping(value = "/{stadiumId}", produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<StadiumDetailResponse> getStadium(@PathVariable Long stadiumId) {
+		StadiumDetailResponse stadiumDetailResponse = stadiumService.getStadium(stadiumId);
+		return ResponseEntity.ok(stadiumDetailResponse);
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/stadium/mapper/StadiumMapper.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/stadium/mapper/StadiumMapper.java
@@ -1,5 +1,6 @@
 package com.goodseats.seatviewreviews.domain.stadium.mapper;
 
+import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumDetailResponse;
 import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumsElementResponse;
 import com.goodseats.seatviewreviews.domain.stadium.model.entity.Stadium;
 
@@ -11,5 +12,9 @@ public class StadiumMapper {
 
 	public static StadiumsElementResponse toStadiumsElementResponse(Stadium stadium) {
 		return new StadiumsElementResponse(stadium.getId(), stadium.getName(), stadium.getHomeTeam());
+	}
+
+	public static StadiumDetailResponse toStadiumDetailResponse(Stadium stadium) {
+		return new StadiumDetailResponse(stadium.getName(), stadium.getAddress());
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/stadium/model/dto/StadiumDetailResponse.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/stadium/model/dto/StadiumDetailResponse.java
@@ -1,0 +1,4 @@
+package com.goodseats.seatviewreviews.domain.stadium.model.dto;
+
+public record StadiumDetailResponse(String stadiumName, String address) {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/stadium/service/StadiumService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/stadium/service/StadiumService.java
@@ -5,9 +5,13 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.goodseats.seatviewreviews.common.error.exception.ErrorCode;
+import com.goodseats.seatviewreviews.common.error.exception.NotFoundException;
 import com.goodseats.seatviewreviews.domain.stadium.mapper.StadiumMapper;
+import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumDetailResponse;
 import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumsElementResponse;
 import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumsResponse;
+import com.goodseats.seatviewreviews.domain.stadium.model.entity.Stadium;
 import com.goodseats.seatviewreviews.domain.stadium.repository.StadiumRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -26,5 +30,13 @@ public class StadiumService {
 				.toList();
 
 		return new StadiumsResponse(elementResponses);
+	}
+
+	@Transactional(readOnly = true)
+	public StadiumDetailResponse getStadium(Long stadiumId) {
+		Stadium stadium = stadiumRepository.findById(stadiumId)
+				.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND));
+
+		return StadiumMapper.toStadiumDetailResponse(stadium);
 	}
 }

--- a/src/test/java/com/goodseats/seatviewreviews/domain/stadium/controller/StadiumControllerTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/stadium/controller/StadiumControllerTest.java
@@ -57,7 +57,35 @@ class StadiumControllerTest {
 				.andExpect(status().isOk())
 				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 				.andExpect(content().json(objectMapper.writeValueAsString(stadiumsResponse)))
-				.andDo(print())
-				.andReturn();
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("Success - 경기장 상세 조회에 성공하고 200 으로 응답한다")
+	void getStadiumSuccess() throws Exception {
+		// given
+		Stadium stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
+		Stadium savedStadium = stadiumRepository.save(stadium);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/stadiums/{stadiumId}", savedStadium.getId())
+						.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("stadiumName").value(savedStadium.getName()))
+				.andExpect(jsonPath("address").value(savedStadium.getAddress()))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("Fail - 해당하는 경기장 id 가 없으면 경기장 상세 조회에 실패하고 404 로 응답한다")
+	void getStadiumFailByNotFound() throws Exception {
+		// given
+		Long wrongStadiumId = -1L;
+
+		// when & then
+		mockMvc.perform(get("/api/v1/stadiums/{stadiumId}", wrongStadiumId)
+						.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNotFound())
+				.andDo(print());
 	}
 }

--- a/src/test/java/com/goodseats/seatviewreviews/domain/stadium/service/StadiumServiceTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/stadium/service/StadiumServiceTest.java
@@ -1,9 +1,11 @@
 package com.goodseats.seatviewreviews.domain.stadium.service;
 
+import static com.goodseats.seatviewreviews.common.error.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,6 +14,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.goodseats.seatviewreviews.common.error.exception.NotFoundException;
+import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumDetailResponse;
 import com.goodseats.seatviewreviews.domain.stadium.model.dto.StadiumsResponse;
 import com.goodseats.seatviewreviews.domain.stadium.model.entity.Stadium;
 import com.goodseats.seatviewreviews.domain.stadium.model.vo.HomeTeam;
@@ -47,5 +51,35 @@ class StadiumServiceTest {
 					.ignoringFields("stadiumId")
 					.isEqualTo(stadiums.get(i));
 		}
+	}
+
+	@Test
+	@DisplayName("Success - 경기장 상세 조회에 성공한다")
+	void getStadiumSuccess() {
+		// given
+		Long stadiumId = 1L;
+		Stadium stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
+		when(stadiumRepository.findById(stadiumId)).thenReturn(Optional.of(stadium));
+
+		// when
+		StadiumDetailResponse stadiumDetailResponse = stadiumService.getStadium(stadiumId);
+
+		// then
+		verify(stadiumRepository).findById(stadiumId);
+		assertThat(stadiumDetailResponse.stadiumName()).isEqualTo(stadium.getName());
+		assertThat(stadiumDetailResponse.address()).isEqualTo(stadium.getAddress());
+	}
+
+	@Test
+	@DisplayName("Fail - 해당하는 경기장 id 가 없으면 경기장 상세 조회에 실패한다")
+	void getStadiumFailByNotFound() {
+		// given
+		Long stadiumId = 1L;
+		when(stadiumRepository.findById(stadiumId)).thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> stadiumService.getStadium(stadiumId))
+				.isExactlyInstanceOf(NotFoundException.class)
+				.hasMessage(NOT_FOUND.getMessage());
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #32 

### 내용
- 경기장 상세 조회 API 구현
  - 사용자가 경기장 상세 조회 요청 시에 화면에는 경기장 정보와 경기장의 좌석 구역 목록이 나타나야한다. 다만, 경기장 상세 조회 API 의 응답에 경기장 정보와 좌석 구역 목록을 함께 준다면 API 가 화면에 종속적이게 되므로 API 의 재사용성이 떨어진다.
  - 그러므로, 백엔드에서는 **경기장 상세 조회 API** 와 **좌석 구역 목록 조회 API 2개로 분리**하고, 프론트에서 두 API 를 호출하여 화면을 그리도록 설계하였다.
 - 경기장 상세 조회 API 의 테스트 작성