### PR TITLE
Fix: MemberService 메서드에 @Transactional 어노테이션 추가

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/domain/member/service/MemberService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.goodseats.seatviewreviews.domain.member.service;
 import static com.goodseats.seatviewreviews.common.error.exception.ErrorCode.*;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.goodseats.seatviewreviews.common.error.exception.AuthenticationException;
 import com.goodseats.seatviewreviews.common.error.exception.DuplicatedException;
@@ -22,6 +23,7 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
 
+	@Transactional
 	public Long signUp(MemberSignUpRequest memberSignUpRequest) {
 		validateDuplicateEmail(memberSignUpRequest.loginEmail());
 		validateDuplicateNickname(memberSignUpRequest.nickname());
@@ -32,6 +34,7 @@ public class MemberService {
 		return savedMember.getId();
 	}
 
+	@Transactional(readOnly = true)
 	public AuthenticationDTO login(MemberLoginRequest memberLoginRequest) {
 		return memberRepository.findByLoginEmail(memberLoginRequest.loginEmail())
 				.filter(member -> passwordEncoder.isMatch(memberLoginRequest.password(), member.getPassword()))


### PR DESCRIPTION
### 관련 이슈
- close #42 

### 내용
- @Transactional 을 서비스 메서드에 추가하지 않아도 Spring Data JPA 의 save, findById 등의 메서드 내부에 @Transactional 이 붙어있어서 DB 에 저장하고 조회하는 기능이 동작한다. 다만, 현재 OSIV 를 꺼놓은 상태이므로 서비스 메서드 안에서 엔티티들이 바로 준영속 상태가 되기에 어노테이션을 붙여주었다.