### PR TITLE
Feat: 후기 생성 API 구현

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/controller/ReviewController.java
@@ -1,0 +1,41 @@
+package com.goodseats.seatviewreviews.domain.review.controller;
+
+import static com.goodseats.seatviewreviews.domain.member.model.vo.MemberAuthority.*;
+
+import java.net.URI;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
+
+import com.goodseats.seatviewreviews.common.security.Authority;
+import com.goodseats.seatviewreviews.common.security.SessionConstant;
+import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
+import com.goodseats.seatviewreviews.domain.review.model.dto.request.ReviewCreateRequest;
+import com.goodseats.seatviewreviews.domain.review.service.ReviewService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/reviews")
+public class ReviewController {
+
+	private final ReviewService reviewService;
+
+	@Authority(authorities = {USER, ADMIN})
+	@PostMapping
+	public ResponseEntity<Void> createReview(
+			@Valid @ModelAttribute ReviewCreateRequest reviewCreateRequest,
+			@SessionAttribute(value = SessionConstant.LOGIN_MEMBER_INFO, required = false) AuthenticationDTO authenticationDTO
+	) {
+
+		Long reviewId = reviewService.createReview(reviewCreateRequest, authenticationDTO.memberId());
+		return ResponseEntity.created(URI.create("/api/v1/reviews/" + reviewId)).build();
+	}
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/controller/ReviewController.java
@@ -4,8 +4,10 @@ import static com.goodseats.seatviewreviews.domain.member.model.vo.MemberAuthori
 
 import java.net.URI;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,13 +31,14 @@ public class ReviewController {
 	private final ReviewService reviewService;
 
 	@Authority(authorities = {USER, ADMIN})
-	@PostMapping
+	@PostMapping(consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
 	public ResponseEntity<Void> createReview(
 			@Valid @ModelAttribute ReviewCreateRequest reviewCreateRequest,
-			@SessionAttribute(value = SessionConstant.LOGIN_MEMBER_INFO, required = false) AuthenticationDTO authenticationDTO
+			@SessionAttribute(value = SessionConstant.LOGIN_MEMBER_INFO) AuthenticationDTO authenticationDTO,
+			HttpServletRequest request
 	) {
 
 		Long reviewId = reviewService.createReview(reviewCreateRequest, authenticationDTO.memberId());
-		return ResponseEntity.created(URI.create("/api/v1/reviews/" + reviewId)).build();
+		return ResponseEntity.created(URI.create(request.getRequestURI() + "/" + reviewId)).build();
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/mapper/ReviewMapper.java
@@ -1,0 +1,23 @@
+package com.goodseats.seatviewreviews.domain.review.mapper;
+
+import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
+import com.goodseats.seatviewreviews.domain.review.model.dto.request.ReviewCreateRequest;
+import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
+import com.goodseats.seatviewreviews.domain.seat.model.entity.Seat;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewMapper {
+
+	public static Review toEntity(ReviewCreateRequest reviewCreateRequest, Member member, Seat seat) {
+		return new Review(
+				reviewCreateRequest.title(),
+				reviewCreateRequest.content(),
+				reviewCreateRequest.score(),
+				member,
+				seat
+		);
+	}
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/model/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/model/dto/request/ReviewCreateRequest.java
@@ -1,0 +1,16 @@
+package com.goodseats.seatviewreviews.domain.review.model.dto.request;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.constraints.Length;
+
+public record ReviewCreateRequest(
+		@NotBlank @Length(max = 50) String title,
+		@NotBlank @Length(max = 2000) String content,
+		@Min(0) @Max(5) int score,
+		@NotNull Long seatId
+) {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,8 @@
+package com.goodseats.seatviewreviews.domain.review.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/service/ReviewService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/service/ReviewService.java
@@ -1,0 +1,40 @@
+package com.goodseats.seatviewreviews.domain.review.service;
+
+import static com.goodseats.seatviewreviews.common.error.exception.ErrorCode.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goodseats.seatviewreviews.common.error.exception.NotFoundException;
+import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
+import com.goodseats.seatviewreviews.domain.member.repository.MemberRepository;
+import com.goodseats.seatviewreviews.domain.review.mapper.ReviewMapper;
+import com.goodseats.seatviewreviews.domain.review.model.dto.request.ReviewCreateRequest;
+import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
+import com.goodseats.seatviewreviews.domain.review.repository.ReviewRepository;
+import com.goodseats.seatviewreviews.domain.seat.model.entity.Seat;
+import com.goodseats.seatviewreviews.domain.seat.repository.SeatRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+	private final ReviewRepository reviewRepository;
+	private final MemberRepository memberRepository;
+	private final SeatRepository seatRepository;
+
+	@Transactional
+	public Long createReview(ReviewCreateRequest reviewCreateRequest, Long memberId) {
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new NotFoundException(NOT_FOUND));
+		Seat seat = seatRepository.findById(reviewCreateRequest.seatId())
+				.orElseThrow(() -> new NotFoundException(NOT_FOUND));
+
+		Review review = ReviewMapper.toEntity(reviewCreateRequest, member, seat);
+		Review savedReview = reviewRepository.save(review);
+
+		return savedReview.getId();
+	}
+}

--- a/src/test/java/com/goodseats/seatviewreviews/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/review/controller/ReviewControllerTest.java
@@ -1,0 +1,119 @@
+package com.goodseats.seatviewreviews.domain.review.controller;
+
+import static com.goodseats.seatviewreviews.common.security.SessionConstant.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
+import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
+import com.goodseats.seatviewreviews.domain.member.model.vo.MemberAuthority;
+import com.goodseats.seatviewreviews.domain.member.repository.MemberRepository;
+import com.goodseats.seatviewreviews.domain.review.model.dto.request.ReviewCreateRequest;
+import com.goodseats.seatviewreviews.domain.seat.model.entity.Seat;
+import com.goodseats.seatviewreviews.domain.seat.model.entity.SeatGrade;
+import com.goodseats.seatviewreviews.domain.seat.model.entity.SeatSection;
+import com.goodseats.seatviewreviews.domain.seat.repository.SeatGradeRepository;
+import com.goodseats.seatviewreviews.domain.seat.repository.SeatRepository;
+import com.goodseats.seatviewreviews.domain.seat.repository.SeatSectionRepository;
+import com.goodseats.seatviewreviews.domain.stadium.model.entity.Stadium;
+import com.goodseats.seatviewreviews.domain.stadium.model.vo.HomeTeam;
+import com.goodseats.seatviewreviews.domain.stadium.repository.StadiumRepository;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+class ReviewControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private StadiumRepository stadiumRepository;
+
+	@Autowired
+	private SeatGradeRepository seatGradeRepository;
+
+	@Autowired
+	private SeatSectionRepository seatSectionRepository;
+
+	@Autowired
+	private SeatRepository seatRepository;
+
+	@Test
+	@DisplayName("Success - 후기 생성에 성공하고 200 응답한다")
+	void createReviewSuccess() throws Exception {
+		// given
+		Member member = new Member("test@test.com", "test", "test");
+		Stadium stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
+		SeatGrade seatGrade = new SeatGrade("테이블", "주중 47,000 / 주말 53,000", stadium);
+		SeatSection seatSection = new SeatSection("110", stadium, seatGrade);
+		Seat seat = new Seat("1", seatGrade, seatSection);
+
+		memberRepository.save(member);
+		stadiumRepository.save(stadium);
+		seatGradeRepository.save(seatGrade);
+		seatSectionRepository.save(seatSection);
+		seatRepository.save(seat);
+
+		AuthenticationDTO authenticationDTO = new AuthenticationDTO(member.getId(), MemberAuthority.USER);
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute(LOGIN_MEMBER_INFO, authenticationDTO);
+
+		ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(
+				"테스트 제목", "테스트 내용", 5, seat.getId()
+		);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/reviews")
+						.session(session)
+						.param("title", reviewCreateRequest.title())
+						.param("content", reviewCreateRequest.content())
+						.param("score", String.valueOf(reviewCreateRequest.score()))
+						.param("seatId", String.valueOf(reviewCreateRequest.seatId()))
+						.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+						.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated());
+	}
+
+	@Test
+	@DisplayName("Fail - 후기 작성 하려는 좌석의 id 가 없으면 실패하고 404 응답한다")
+	void createReviewFailByNotFoundSeatId() throws Exception {
+		// given
+		Long wrongSeatId=0L;
+		Member member = new Member("test@test.com", "test", "test");
+
+		memberRepository.save(member);
+
+		AuthenticationDTO authenticationDTO = new AuthenticationDTO(member.getId(), MemberAuthority.USER);
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute(LOGIN_MEMBER_INFO, authenticationDTO);
+
+		ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(
+				"테스트 제목", "테스트 내용", 5, wrongSeatId
+		);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/reviews")
+						.session(session)
+						.param("title", reviewCreateRequest.title())
+						.param("content", reviewCreateRequest.content())
+						.param("score", String.valueOf(reviewCreateRequest.score()))
+						.param("seatId", String.valueOf(reviewCreateRequest.seatId()))
+						.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+						.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNotFound());
+	}
+}

--- a/src/test/java/com/goodseats/seatviewreviews/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/review/service/ReviewServiceTest.java
@@ -1,0 +1,112 @@
+package com.goodseats.seatviewreviews.domain.review.service;
+
+import static com.goodseats.seatviewreviews.common.error.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.goodseats.seatviewreviews.common.error.exception.NotFoundException;
+import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
+import com.goodseats.seatviewreviews.domain.member.repository.MemberRepository;
+import com.goodseats.seatviewreviews.domain.review.model.dto.request.ReviewCreateRequest;
+import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
+import com.goodseats.seatviewreviews.domain.review.repository.ReviewRepository;
+import com.goodseats.seatviewreviews.domain.seat.model.entity.Seat;
+import com.goodseats.seatviewreviews.domain.seat.model.entity.SeatGrade;
+import com.goodseats.seatviewreviews.domain.seat.model.entity.SeatSection;
+import com.goodseats.seatviewreviews.domain.seat.repository.SeatRepository;
+import com.goodseats.seatviewreviews.domain.stadium.model.entity.Stadium;
+import com.goodseats.seatviewreviews.domain.stadium.model.vo.HomeTeam;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+	@Mock
+	private ReviewRepository reviewRepository;
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private SeatRepository seatRepository;
+
+	@InjectMocks
+	private ReviewService reviewService;
+
+	@Test
+	@DisplayName("Success - 후기 생성에 성공한다")
+	void createReviewSuccess() {
+		// given
+		Long seatId = 1L;
+		Long memberId = 1L;
+		Long reviewId = 1L;
+		ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(
+				"테스트 제목", "테스트 내용", 5, seatId
+		);
+
+		Member member = new Member("test@test.com", "test", "test");
+		ReflectionTestUtils.setField(member, "id", memberId);
+
+		Stadium stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
+		SeatGrade seatGrade = new SeatGrade("테이블", "주중 47,000 / 주말 53,000", stadium);
+		SeatSection seatSection = new SeatSection("110", stadium, seatGrade);
+		Seat seat = new Seat("1", seatGrade, seatSection);
+		ReflectionTestUtils.setField(seat, "id", seatId);
+
+		Review review = new Review(
+				reviewCreateRequest.title(), reviewCreateRequest.content(), reviewCreateRequest.score(), member, seat
+		);
+		ReflectionTestUtils.setField(review, "id", reviewId);
+
+		when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+		when(seatRepository.findById(seatId)).thenReturn(Optional.of(seat));
+		when(reviewRepository.save(any(Review.class))).thenReturn(review);
+
+		// when
+		Long savedReviewId = reviewService.createReview(reviewCreateRequest, memberId);
+
+		// then
+		verify(memberRepository).findById(memberId);
+		verify(seatRepository).findById(seatId);
+		verify(reviewRepository).save(any(Review.class));
+		assertThat(savedReviewId).isEqualTo(review.getId());
+	}
+
+	@Test
+	@DisplayName("Fail - 후기 작성 하려는 좌석의 id 가 없으면 실패한다")
+	void createReviewFailByNotFoundSeatId() {
+		// given
+		Long seatId = 1L;
+		Long memberId = 1L;
+		ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(
+				"테스트 제목", "테스트 내용", 5, seatId
+		);
+
+		Member member = new Member("test@test.com", "test", "test");
+		ReflectionTestUtils.setField(member, "id", memberId);
+
+		Stadium stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
+		SeatGrade seatGrade = new SeatGrade("테이블", "주중 47,000 / 주말 53,000", stadium);
+		SeatSection seatSection = new SeatSection("110", stadium, seatGrade);
+		Seat seat = new Seat("1", seatGrade, seatSection);
+		ReflectionTestUtils.setField(seat, "id", seatId);
+
+		when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+		when(seatRepository.findById(seatId)).thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> reviewService.createReview(reviewCreateRequest, memberId))
+				.isExactlyInstanceOf(NotFoundException.class)
+				.hasMessage(NOT_FOUND.getMessage());
+	}
+
+}


### PR DESCRIPTION
### 관련 이슈
- close #55 

### 내용
- 후기 생성 API 구현
  - 이 API 에서는 후기 제목, 본문, 좌석 평점만을 생성하고 저장하도록 함.
  - 후기와 관련된 이미지의 저장은 별도의 API 로 분리하도록 함.
    - 이미지는 많은 도메인에서 쓰이니 API 의 재사용성을 높이기 위함.
- 후기 생성 API 관련 테스트 작성 