### PR TITLE
Hotfix: AuthenticationInterceptor 로직에서 세션이 없는 경우의 예외 처리 추가

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/common/security/AuthenticationInterceptor.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/security/AuthenticationInterceptor.java
@@ -29,6 +29,11 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 		}
 
 		HttpSession session = request.getSession(false);
+
+		if (Objects.isNull(session)) {
+			throw new AuthenticationException(UNAUTHORIZED);
+		}
+
 		AuthenticationDTO authenticationDTO = (AuthenticationDTO)session.getAttribute(LOGIN_MEMBER_INFO);
 
 		if (Objects.isNull(authenticationDTO)) {


### PR DESCRIPTION
### 관련 이슈
- close #60 

### 내용
- Authority 어노테이션이 붙은 API 의 요청임에도 세션이 존재하지 않는다면 예외가 발생해야 함.
  - 로그인 시 세션이 없다면 만들고, 그 안에 인증 객체를 넣도록 하였기 때문.