### PR TITLE
Fix: docker-compose 파일 수정사항 반영

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,13 +10,14 @@ services:
     environment:
       TZ: Asia/Seoul
     volumes:
-      - seat-view:/var/lib/seat-view/db
+      - seat-view:/var/lib/mysql
       - ./my.cnf:/etc/mysql/my.cnf
       - ./sql/init.sql:/docker-entrypoint-initdb.d/init.sql
       - ./sql/stadium.sql:/docker-entrypoint-initdb.d/stadium.sql
       - ./sql/jamsil-seat-grade.sql:/docker-entrypoint-initdb.d/jamsil-seat-grade.sql
       - ./sql/jamsil-seat-section.sql:/docker-entrypoint-initdb.d/jamsil-seat-section.sql
       - ./sql/jamsil-seat.sql:/docker-entrypoint-initdb.d/jamsil-seat.sql
+    command: bash -c "chmod 644 /etc/mysql/my.cnf && docker-entrypoint.sh mysqld"
     restart: always
 
 volumes:


### PR DESCRIPTION
### 관련 이슈
- close #65 

### 내용
- 마운트되는 컨테이너 내부 경로를 /var/lib/mysql 로 수정
  - mysql 컨테이너가 데이터를 저장하는 기본 경로가 /var/lib/mysql 이기 때문
- 컨테이너 생성 전에 /etc/mysql/my.cnf 파일에 644 권한 주게 함
  - 컨테이너를 새로 생성할 때마다 644 권한을 수동으로 주지 않도록 하기 위함