### PR TITLE
Feat: 이미지 저장 API 구현

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/controller/ImageController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/controller/ImageController.java
@@ -1,0 +1,37 @@
+package com.goodseats.seatviewreviews.domain.image.controller;
+
+import static com.goodseats.seatviewreviews.domain.member.model.vo.MemberAuthority.*;
+import static org.springframework.http.MediaType.*;
+
+import java.net.URI;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goodseats.seatviewreviews.common.security.Authority;
+import com.goodseats.seatviewreviews.domain.image.model.dto.request.ImageCreateRequest;
+import com.goodseats.seatviewreviews.domain.image.service.ImageService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/images")
+public class ImageController {
+
+	private final ImageService imageService;
+
+	@Authority(authorities = {USER, ADMIN})
+	@PostMapping(consumes = MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
+	public ResponseEntity<Void> createImage(
+			@ModelAttribute ImageCreateRequest imageCreateRequest, HttpServletRequest request
+	) {
+		Long savedImageId = imageService.createImage(imageCreateRequest);
+		return ResponseEntity.created(URI.create(request.getRequestURI() + "/" + savedImageId)).build();
+	}
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/event/ImageEventListener.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/event/ImageEventListener.java
@@ -1,0 +1,24 @@
+package com.goodseats.seatviewreviews.domain.image.event;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.goodseats.seatviewreviews.common.file.FileStorageService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ImageEventListener {
+
+	private final FileStorageService fileStorageService;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
+	public void rollbackUpload(RollbackUploadEvent rollbackUploadEvent) {
+		fileStorageService.delete(
+				rollbackUploadEvent.getImage().getImageType().getSubPath(),
+				rollbackUploadEvent.getImage().getSavedName()
+		);
+	}
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/event/RollbackUploadEvent.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/event/RollbackUploadEvent.java
@@ -1,0 +1,13 @@
+package com.goodseats.seatviewreviews.domain.image.event;
+
+import com.goodseats.seatviewreviews.domain.image.model.entity.Image;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RollbackUploadEvent {
+
+	private final Image image;
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/mapper/ImageMapper.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/mapper/ImageMapper.java
@@ -1,0 +1,19 @@
+package com.goodseats.seatviewreviews.domain.image.mapper;
+
+import com.goodseats.seatviewreviews.domain.image.model.dto.request.ImageCreateRequest;
+import com.goodseats.seatviewreviews.domain.image.model.entity.Image;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ImageMapper {
+
+	public static Image toEntity(ImageCreateRequest imageCreateRequest, String imageUrl) {
+		return new Image(imageCreateRequest.imageType(),
+				imageCreateRequest.referenceId(),
+				imageUrl,
+				imageCreateRequest.multipartFile().getOriginalFilename()
+		);
+	}
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/model/dto/request/ImageCreateRequest.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/model/dto/request/ImageCreateRequest.java
@@ -1,0 +1,8 @@
+package com.goodseats.seatviewreviews.domain.image.model.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.goodseats.seatviewreviews.domain.image.model.vo.ImageType;
+
+public record ImageCreateRequest(MultipartFile multipartFile, ImageType imageType, Long referenceId) {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/model/vo/ImageType.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/model/vo/ImageType.java
@@ -1,8 +1,16 @@
 package com.goodseats.seatviewreviews.domain.image.model.vo;
 
+import lombok.Getter;
+
+@Getter
 public enum ImageType {
-	MEMBER_PROFILE,
-	REVIEW_TICKET,
-	REVIEW_SEAT_VIEW,
-	STADIUM
+	MEMBER_PROFILE("members"),
+	REVIEW("reviews"),
+	STADIUM("stadiums");
+
+	private final String subPath;
+
+	ImageType(String subPath) {
+		this.subPath = subPath;
+	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/repository/ImageRepository.java
@@ -1,0 +1,8 @@
+package com.goodseats.seatviewreviews.domain.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goodseats.seatviewreviews.domain.image.model.entity.Image;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/service/ImageService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/service/ImageService.java
@@ -38,8 +38,8 @@ public class ImageService {
 		);
 		Image image = ImageMapper.toEntity(imageCreateRequest, imageUrl);
 		applicationEventPublisher.publishEvent(new RollbackUploadEvent(image));
-		imageRepository.save(image);
-		return image.getId();
+		Image savedImage = imageRepository.save(image);
+		return savedImage.getId();
 	}
 
 	private boolean isNotImage(MultipartFile multipartFile) {

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/service/ImageService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/service/ImageService.java
@@ -1,0 +1,50 @@
+package com.goodseats.seatviewreviews.domain.image.service;
+
+import static com.goodseats.seatviewreviews.common.error.exception.ErrorCode.*;
+
+import java.util.Objects;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.goodseats.seatviewreviews.common.file.FileStorageService;
+import com.goodseats.seatviewreviews.domain.image.event.RollbackUploadEvent;
+import com.goodseats.seatviewreviews.domain.image.mapper.ImageMapper;
+import com.goodseats.seatviewreviews.domain.image.model.dto.request.ImageCreateRequest;
+import com.goodseats.seatviewreviews.domain.image.model.entity.Image;
+import com.goodseats.seatviewreviews.domain.image.repository.ImageRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+	private final ImageRepository imageRepository;
+	private final FileStorageService fileStorageService;
+	private final ApplicationEventPublisher applicationEventPublisher;
+
+	@Transactional
+	public Long createImage(ImageCreateRequest imageCreateRequest) {
+		if (isNotImage(imageCreateRequest.multipartFile())) {
+			throw new IllegalArgumentException(BAD_IMAGE_REQUEST.getMessage());
+		}
+
+		String imageUrl = fileStorageService.upload(
+				imageCreateRequest.multipartFile(), imageCreateRequest.imageType().getSubPath()
+		);
+		Image image = ImageMapper.toEntity(imageCreateRequest, imageUrl);
+		applicationEventPublisher.publishEvent(new RollbackUploadEvent(image));
+		imageRepository.save(image);
+		return image.getId();
+	}
+
+	private boolean isNotImage(MultipartFile multipartFile) {
+		return !Objects.equals(multipartFile.getContentType(), MediaType.IMAGE_GIF_VALUE)
+				&& !Objects.equals(multipartFile.getContentType(), MediaType.IMAGE_JPEG_VALUE)
+				&& !Objects.equals(multipartFile.getContentType(), MediaType.IMAGE_PNG_VALUE);
+	}
+}

--- a/src/test/java/com/goodseats/seatviewreviews/domain/image/controller/ImageControllerTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/image/controller/ImageControllerTest.java
@@ -1,0 +1,119 @@
+package com.goodseats.seatviewreviews.domain.image.controller;
+
+import static com.goodseats.seatviewreviews.common.security.SessionConstant.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goodseats.seatviewreviews.domain.image.model.vo.ImageType;
+import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
+import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
+import com.goodseats.seatviewreviews.domain.member.model.vo.MemberAuthority;
+import com.goodseats.seatviewreviews.domain.member.repository.MemberRepository;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+class ImageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("Success - 이미지 저장에 성공하고 201 로 응답한다")
+	void createImageSuccess() throws Exception {
+		// given
+		Member member = new Member("test@test.com", "test", "test");
+		memberRepository.save(member);
+
+		AuthenticationDTO authenticationDTO = new AuthenticationDTO(member.getId(), MemberAuthority.USER);
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute(LOGIN_MEMBER_INFO, authenticationDTO);
+
+		MockMultipartFile multipartFile = new MockMultipartFile(
+				"multipartFile", "testOriginalName.png", IMAGE_PNG_VALUE, "testContent".getBytes()
+		);
+		ImageType imageType = ImageType.REVIEW;
+		Long referenceId = 1L;
+
+		// when & then
+		mockMvc.perform(multipart("/api/v1/images")
+						.file(multipartFile)
+						.param("imageType", imageType.toString())
+						.param("referenceId", referenceId.toString())
+						.contentType(MULTIPART_FORM_DATA)
+						.accept(APPLICATION_JSON)
+						.session(session))
+				.andExpect(status().isCreated())
+				.andDo(print());
+	}
+
+	@Nested
+	@DisplayName("createImageFail")
+	class createImageFail {
+		@Test
+		@DisplayName("Fail - 이미지가 아닌 파일 요청이 들어오면 저장에 실패하고 400 응답한다")
+		void createImageFailByNotImageRequest() throws Exception {
+			// given
+			Member member = new Member("test@test.com", "test", "test");
+			memberRepository.save(member);
+
+			AuthenticationDTO authenticationDTO = new AuthenticationDTO(member.getId(), MemberAuthority.USER);
+			MockHttpSession session = new MockHttpSession();
+			session.setAttribute(LOGIN_MEMBER_INFO, authenticationDTO);
+
+			MockMultipartFile multipartFile = new MockMultipartFile(
+					"multipartFile", "testOriginalName.png", APPLICATION_PDF_VALUE, "testContent".getBytes()
+			);
+			ImageType imageType = ImageType.REVIEW;
+			Long referenceId = 1L;
+
+			// when & then
+			mockMvc.perform(multipart("/api/v1/images")
+							.file(multipartFile)
+							.param("imageType", imageType.toString())
+							.param("referenceId", referenceId.toString())
+							.contentType(MULTIPART_FORM_DATA)
+							.accept(APPLICATION_JSON)
+							.session(session))
+					.andExpect(status().isBadRequest())
+					.andDo(print());
+		}
+
+		@Test
+		@DisplayName("Fail - 비회원이 이미지 저장을 요청하면 실패하고 401 응답한다")
+		void createImageFailByUnauthorized() throws Exception {
+			// given
+			MockMultipartFile multipartFile = new MockMultipartFile(
+					"multipartFile", "testOriginalName.png", APPLICATION_PDF_VALUE, "testContent".getBytes()
+			);
+			ImageType imageType = ImageType.REVIEW;
+			Long referenceId = 1L;
+
+			// when & then
+			mockMvc.perform(multipart("/api/v1/images")
+							.file(multipartFile)
+							.param("imageType", imageType.toString())
+							.param("referenceId", referenceId.toString())
+							.contentType(MULTIPART_FORM_DATA)
+							.accept(APPLICATION_JSON))
+					.andExpect(status().isUnauthorized())
+					.andDo(print());
+		}
+	}
+}

--- a/src/test/java/com/goodseats/seatviewreviews/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/image/service/ImageServiceTest.java
@@ -1,0 +1,87 @@
+package com.goodseats.seatviewreviews.domain.image.service;
+
+import static com.goodseats.seatviewreviews.common.error.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.goodseats.seatviewreviews.common.file.FileStorageService;
+import com.goodseats.seatviewreviews.domain.image.event.RollbackUploadEvent;
+import com.goodseats.seatviewreviews.domain.image.model.dto.request.ImageCreateRequest;
+import com.goodseats.seatviewreviews.domain.image.model.entity.Image;
+import com.goodseats.seatviewreviews.domain.image.model.vo.ImageType;
+import com.goodseats.seatviewreviews.domain.image.repository.ImageRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ImageServiceTest {
+
+	@Mock
+	private ImageRepository imageRepository;
+
+	@Mock
+	private FileStorageService fileStorageService;
+
+	@Mock
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@InjectMocks
+	private ImageService imageService;
+
+	@Test
+	@DisplayName("Success - 이미지 저장에 성공한다")
+	void createImageSuccess() {
+		// given
+		MockMultipartFile multipartFile = new MockMultipartFile(
+				"testName", "testOriginalName", IMAGE_PNG_VALUE, "testContent".getBytes()
+		);
+		Long referenceId = 1L;
+		ImageType imageType = ImageType.REVIEW;
+		ImageCreateRequest imageCreateRequest = new ImageCreateRequest(multipartFile, ImageType.REVIEW, referenceId);
+
+		Long imageId = 1L;
+		String imageUrl = "testUrl";
+		Image image = new Image(imageType, referenceId, imageUrl, multipartFile.getOriginalFilename());
+		ReflectionTestUtils.setField(image, "id", imageId);
+
+		when(fileStorageService.upload(imageCreateRequest.multipartFile(), imageCreateRequest.imageType().getSubPath()))
+				.thenReturn(imageUrl);
+		doNothing().when(applicationEventPublisher).publishEvent(any(RollbackUploadEvent.class));
+		when(imageRepository.save(any(Image.class))).thenReturn(image);
+
+		// when
+		Long savedImageId = imageService.createImage(imageCreateRequest);
+
+		// then
+		verify(fileStorageService).upload(imageCreateRequest.multipartFile(), imageCreateRequest.imageType().getSubPath());
+		verify(applicationEventPublisher).publishEvent(any(RollbackUploadEvent.class));
+		verify(imageRepository).save(any(Image.class));
+		assertThat(savedImageId).isEqualTo(imageId);
+	}
+
+	@Test
+	@DisplayName("Fail - 이미지가 아닌 파일 요청이 들어오면 저장에 실패한다")
+	void createImageFailByNotImageRequest() {
+		// given
+		MockMultipartFile multipartFile = new MockMultipartFile(
+				"testName", "testOriginalName", APPLICATION_PDF_VALUE, "testContent".getBytes()
+		);
+		Long referenceId = 1L;
+		ImageType imageType = ImageType.REVIEW;
+		ImageCreateRequest imageCreateRequest = new ImageCreateRequest(multipartFile, ImageType.REVIEW, referenceId);
+
+		// when & then
+		assertThatThrownBy(() -> imageService.createImage(imageCreateRequest))
+				.isExactlyInstanceOf(IllegalArgumentException.class)
+				.hasMessage(BAD_IMAGE_REQUEST.getMessage());
+	}
+}


### PR DESCRIPTION
### 관련 이슈
- close #63 

### 내용
- ImageType Enum 에 subPath 필드 추가
  - subPath 는 이미지 타입마다의 파일 스토리지에 저장되는 하위 경로를 의미함
- 이미지 외부 저장소와 DB 의 생명주기를 맞추는 로직 구현
  - @TransactionalEventListener 를 이용하여 DB 트랜잭션이 롤백되면 S3 에 저장된 이미지를 삭제하도록 함
- 이미지 저장 API 구현
- 이미지 저장 API 관련 테스트 작성