### PR TITLE
Fix: 이미지 저장 API 응답의 헤더 Location 값 수정

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/controller/ImageController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/controller/ImageController.java
@@ -5,8 +5,6 @@ import static org.springframework.http.MediaType.*;
 
 import java.net.URI;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,10 +26,8 @@ public class ImageController {
 
 	@Authority(authorities = {USER, ADMIN})
 	@PostMapping(consumes = MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
-	public ResponseEntity<Void> createImage(
-			@ModelAttribute ImageCreateRequest imageCreateRequest, HttpServletRequest request
-	) {
-		Long savedImageId = imageService.createImage(imageCreateRequest);
-		return ResponseEntity.created(URI.create(request.getRequestURI() + "/" + savedImageId)).build();
+	public ResponseEntity<Void> createImage(@ModelAttribute ImageCreateRequest imageCreateRequest) {
+		String imageUrl = imageService.createImage(imageCreateRequest);
+		return ResponseEntity.created(URI.create(imageUrl)).build();
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/service/ImageService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/service/ImageService.java
@@ -28,7 +28,7 @@ public class ImageService {
 	private final ApplicationEventPublisher applicationEventPublisher;
 
 	@Transactional
-	public Long createImage(ImageCreateRequest imageCreateRequest) {
+	public String createImage(ImageCreateRequest imageCreateRequest) {
 		if (isNotImage(imageCreateRequest.multipartFile())) {
 			throw new IllegalArgumentException(BAD_IMAGE_REQUEST.getMessage());
 		}
@@ -39,7 +39,7 @@ public class ImageService {
 		Image image = ImageMapper.toEntity(imageCreateRequest, imageUrl);
 		applicationEventPublisher.publishEvent(new RollbackUploadEvent(image));
 		Image savedImage = imageRepository.save(image);
-		return savedImage.getId();
+		return savedImage.getImageUrl();
 	}
 
 	private boolean isNotImage(MultipartFile multipartFile) {

--- a/src/test/java/com/goodseats/seatviewreviews/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/image/service/ImageServiceTest.java
@@ -59,13 +59,13 @@ class ImageServiceTest {
 		when(imageRepository.save(any(Image.class))).thenReturn(image);
 
 		// when
-		Long savedImageId = imageService.createImage(imageCreateRequest);
+		String savedImageUrl = imageService.createImage(imageCreateRequest);
 
 		// then
 		verify(fileStorageService).upload(imageCreateRequest.multipartFile(), imageCreateRequest.imageType().getSubPath());
 		verify(applicationEventPublisher).publishEvent(any(RollbackUploadEvent.class));
 		verify(imageRepository).save(any(Image.class));
-		assertThat(savedImageId).isEqualTo(imageId);
+		assertThat(savedImageUrl).isEqualTo(imageUrl);
 	}
 
 	@Test
@@ -77,7 +77,7 @@ class ImageServiceTest {
 		);
 		Long referenceId = 1L;
 		ImageType imageType = ImageType.REVIEW;
-		ImageCreateRequest imageCreateRequest = new ImageCreateRequest(multipartFile, ImageType.REVIEW, referenceId);
+		ImageCreateRequest imageCreateRequest = new ImageCreateRequest(multipartFile, imageType, referenceId);
 
 		// when & then
 		assertThatThrownBy(() -> imageService.createImage(imageCreateRequest))


### PR DESCRIPTION
### 관련 이슈
- close #73 

### 내용
- 프론트에서 필요한 것이 저장된 이미지의 id 가 아닌 이미지 URL 이므로 이미지 URL 을 반환하도록 변경함