### PR TITLE
Feat: 이미지 삭제 API 구현

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/SeatViewReviewsApplication.java
+++ b/src/main/java/com/goodseats/seatviewreviews/SeatViewReviewsApplication.java
@@ -2,7 +2,9 @@ package com.goodseats.seatviewreviews;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class SeatViewReviewsApplication {
 

--- a/src/main/java/com/goodseats/seatviewreviews/common/error/exception/ErrorCode.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/exception/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
 	DUPLICATED_NICKNAME(409, "중복된 닉네임입니다."),
 	UNAUTHORIZED(401, "인증되지 않은 사용자입니다."),
 	BAD_LOGIN_REQUEST(400, "아이디 혹은 비밀번호가 틀립니다."),
-	BAD_IMAGE_REQUEST(400, "잘못된 이미지 업로드 요청입니다.");
+	BAD_IMAGE_REQUEST(400, "잘못된 이미지 업로드 요청입니다."),
+	ALREADY_DELETED(409, "이미 삭제된 데이터입니다.");
 
 	private final int status;
 	private final String message;

--- a/src/main/java/com/goodseats/seatviewreviews/domain/BaseEntity.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/BaseEntity.java
@@ -1,6 +1,7 @@
 package com.goodseats.seatviewreviews.domain;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
@@ -9,6 +10,9 @@ import javax.persistence.MappedSuperclass;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.goodseats.seatviewreviews.common.error.exception.DuplicatedException;
+import com.goodseats.seatviewreviews.common.error.exception.ErrorCode;
 
 import lombok.Getter;
 
@@ -27,4 +31,12 @@ public abstract class BaseEntity {
 
 	@Column(name = "deleted_at", nullable = true)
 	private LocalDateTime deletedAt;
+
+	public void delete() {
+		if (Objects.nonNull(deletedAt)) {
+			throw new DuplicatedException(ErrorCode.ALREADY_DELETED);
+		}
+
+		deletedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/controller/ImageController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/controller/ImageController.java
@@ -42,7 +42,7 @@ public class ImageController {
 	}
 
 	@Authority(authorities = {USER, ADMIN})
-	@DeleteMapping
+	@DeleteMapping(consumes = APPLICATION_JSON_VALUE)
 	public ResponseEntity<Void> deleteImages(@RequestBody ImageDeleteRequest imageDeleteRequest) {
 		imageService.deleteImages(imageDeleteRequest);
 		return ResponseEntity.noContent().build();

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/controller/ImageController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/controller/ImageController.java
@@ -10,11 +10,13 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.goodseats.seatviewreviews.common.security.Authority;
 import com.goodseats.seatviewreviews.domain.image.model.dto.request.ImageCreateRequest;
+import com.goodseats.seatviewreviews.domain.image.model.dto.request.ImageDeleteRequest;
 import com.goodseats.seatviewreviews.domain.image.service.ImageService;
 
 import lombok.RequiredArgsConstructor;
@@ -37,6 +39,13 @@ public class ImageController {
 	@DeleteMapping("/{imageId}")
 	public ResponseEntity<Void> deleteImage(@PathVariable Long imageId) {
 		imageService.deleteImage(imageId);
+		return ResponseEntity.noContent().build();
+	}
+
+	@Authority(authorities = {USER, ADMIN})
+	@DeleteMapping
+	public ResponseEntity<Void> deleteImages(@RequestBody ImageDeleteRequest imageDeleteRequest) {
+		imageService.deleteImages(imageDeleteRequest);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/controller/ImageController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/controller/ImageController.java
@@ -6,7 +6,9 @@ import static org.springframework.http.MediaType.*;
 import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,5 +31,12 @@ public class ImageController {
 	public ResponseEntity<Void> createImage(@ModelAttribute ImageCreateRequest imageCreateRequest) {
 		String imageUrl = imageService.createImage(imageCreateRequest);
 		return ResponseEntity.created(URI.create(imageUrl)).build();
+	}
+
+	@Authority(authorities = {USER, ADMIN})
+	@DeleteMapping("/{imageId}")
+	public ResponseEntity<Void> deleteImage(@PathVariable Long imageId) {
+		imageService.deleteImage(imageId);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/event/ImageDeleteEvent.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/event/ImageDeleteEvent.java
@@ -1,0 +1,13 @@
+package com.goodseats.seatviewreviews.domain.image.event;
+
+import com.goodseats.seatviewreviews.domain.image.model.entity.Image;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ImageDeleteEvent {
+
+	private final Image image;
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/event/ImageEventListener.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/event/ImageEventListener.java
@@ -1,5 +1,6 @@
 package com.goodseats.seatviewreviews.domain.image.event;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -19,6 +20,15 @@ public class ImageEventListener {
 		fileStorageService.delete(
 				rollbackUploadEvent.getImage().getImageType().getSubPath(),
 				rollbackUploadEvent.getImage().getSavedName()
+		);
+	}
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void rollbackUpload(ImageDeleteEvent imageDeleteEvent) {
+		fileStorageService.delete(
+				imageDeleteEvent.getImage().getImageType().getSubPath(),
+				imageDeleteEvent.getImage().getSavedName()
 		);
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/model/dto/request/ImageDeleteRequest.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/model/dto/request/ImageDeleteRequest.java
@@ -1,0 +1,6 @@
+package com.goodseats.seatviewreviews.domain.image.model.dto.request;
+
+import com.goodseats.seatviewreviews.domain.image.model.vo.ImageType;
+
+public record ImageDeleteRequest(ImageType imageType, Long referenceId) {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/repository/ImageRepository.java
@@ -1,8 +1,13 @@
 package com.goodseats.seatviewreviews.domain.image.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.goodseats.seatviewreviews.domain.image.model.entity.Image;
+import com.goodseats.seatviewreviews.domain.image.model.vo.ImageType;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
+
+	List<Image> findAllByImageTypeAndReferenceId(ImageType imageType, Long referenceId);
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/repository/ImageRepository.java
@@ -9,5 +9,5 @@ import com.goodseats.seatviewreviews.domain.image.model.vo.ImageType;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
-	List<Image> findAllByImageTypeAndReferenceId(ImageType imageType, Long referenceId);
+	List<Image> findAllByImageTypeAndReferenceIdAndDeletedAtIsNull(ImageType imageType, Long referenceId);
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/service/ImageService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/service/ImageService.java
@@ -10,7 +10,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.goodseats.seatviewreviews.common.error.exception.NotFoundException;
 import com.goodseats.seatviewreviews.common.file.FileStorageService;
+import com.goodseats.seatviewreviews.domain.image.event.ImageDeleteEvent;
 import com.goodseats.seatviewreviews.domain.image.event.RollbackUploadEvent;
 import com.goodseats.seatviewreviews.domain.image.mapper.ImageMapper;
 import com.goodseats.seatviewreviews.domain.image.model.dto.request.ImageCreateRequest;
@@ -40,6 +42,19 @@ public class ImageService {
 		applicationEventPublisher.publishEvent(new RollbackUploadEvent(image));
 		Image savedImage = imageRepository.save(image);
 		return savedImage.getImageUrl();
+	}
+
+	@Transactional
+	public void deleteImage(Long imageId) {
+		Image image = imageRepository.findById(imageId)
+				.orElseThrow(() -> new NotFoundException(NOT_FOUND));
+
+		deleteImage(image);
+	}
+
+	private void deleteImage(Image image) {
+		image.delete();
+		applicationEventPublisher.publishEvent(new ImageDeleteEvent(image));
 	}
 
 	private boolean isNotImage(MultipartFile multipartFile) {

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/service/ImageService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/service/ImageService.java
@@ -56,7 +56,7 @@ public class ImageService {
 
 	@Transactional
 	public void deleteImages(ImageDeleteRequest imageDeleteRequest) {
-		List<Image> images = imageRepository.findAllByImageTypeAndReferenceId(
+		List<Image> images = imageRepository.findAllByImageTypeAndReferenceIdAndDeletedAtIsNull(
 				imageDeleteRequest.imageType(), imageDeleteRequest.referenceId()
 		);
 

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/service/ImageService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/service/ImageService.java
@@ -2,6 +2,7 @@ package com.goodseats.seatviewreviews.domain.image.service;
 
 import static com.goodseats.seatviewreviews.common.error.exception.ErrorCode.*;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -16,6 +17,7 @@ import com.goodseats.seatviewreviews.domain.image.event.ImageDeleteEvent;
 import com.goodseats.seatviewreviews.domain.image.event.RollbackUploadEvent;
 import com.goodseats.seatviewreviews.domain.image.mapper.ImageMapper;
 import com.goodseats.seatviewreviews.domain.image.model.dto.request.ImageCreateRequest;
+import com.goodseats.seatviewreviews.domain.image.model.dto.request.ImageDeleteRequest;
 import com.goodseats.seatviewreviews.domain.image.model.entity.Image;
 import com.goodseats.seatviewreviews.domain.image.repository.ImageRepository;
 
@@ -50,6 +52,15 @@ public class ImageService {
 				.orElseThrow(() -> new NotFoundException(NOT_FOUND));
 
 		deleteImage(image);
+	}
+
+	@Transactional
+	public void deleteImages(ImageDeleteRequest imageDeleteRequest) {
+		List<Image> images = imageRepository.findAllByImageTypeAndReferenceId(
+				imageDeleteRequest.imageType(), imageDeleteRequest.referenceId()
+		);
+
+		images.forEach(this::deleteImage);
 	}
 
 	private void deleteImage(Image image) {

--- a/src/test/java/com/goodseats/seatviewreviews/domain/image/controller/ImageControllerTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/image/controller/ImageControllerTest.java
@@ -1,6 +1,7 @@
 package com.goodseats.seatviewreviews.domain.image.controller;
 
 import static com.goodseats.seatviewreviews.common.security.SessionConstant.*;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -17,7 +18,9 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.goodseats.seatviewreviews.domain.image.model.entity.Image;
 import com.goodseats.seatviewreviews.domain.image.model.vo.ImageType;
+import com.goodseats.seatviewreviews.domain.image.repository.ImageRepository;
 import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
 import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
 import com.goodseats.seatviewreviews.domain.member.model.vo.MemberAuthority;
@@ -33,6 +36,9 @@ class ImageControllerTest {
 
 	@Autowired
 	private MemberRepository memberRepository;
+
+	@Autowired
+	private ImageRepository imageRepository;
 
 	@Test
 	@DisplayName("Success - 이미지 저장에 성공하고 200 으로 응답한다")
@@ -116,6 +122,74 @@ class ImageControllerTest {
 							.accept(APPLICATION_JSON))
 					.andExpect(status().isUnauthorized())
 					.andDo(print());
+		}
+	}
+
+	@Test
+	@DisplayName("Success - 이미지 단건 삭제에 성공하고 204 응답한다")
+	void deleteImageSuccess() throws Exception {
+		// given
+		Member member = new Member("test@test.com", "test", "test");
+		memberRepository.save(member);
+
+		AuthenticationDTO authenticationDTO = new AuthenticationDTO(member.getId(), MemberAuthority.USER);
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute(LOGIN_MEMBER_INFO, authenticationDTO);
+
+		Image image = new Image(ImageType.REVIEW, 1L, "testUrl", "테스트 이미지.jpg");
+		Image savedImage = imageRepository.save(image);
+
+		// when
+		mockMvc.perform(delete("/api/v1/images/{imageId}", savedImage.getId())
+						.session(session))
+				.andExpect(status().isNoContent());
+
+		// then
+		assertThat(savedImage.getDeletedAt()).isNotNull();
+	}
+
+	@Nested
+	@DisplayName("deleteImageFail")
+	class DeleteImage {
+
+		@Test
+		@DisplayName("Fail - 삭제하고자 하는 이미지가 존재하지 않으면 실패하고 404 응답한다")
+		void deleteImageFailByNotFound() throws Exception {
+			// given
+			Member member = new Member("test@test.com", "test", "test");
+			memberRepository.save(member);
+
+			AuthenticationDTO authenticationDTO = new AuthenticationDTO(member.getId(), MemberAuthority.USER);
+			MockHttpSession session = new MockHttpSession();
+			session.setAttribute(LOGIN_MEMBER_INFO, authenticationDTO);
+
+			Long imageId = 1L;
+
+			// when & then
+			mockMvc.perform(delete("/api/v1/images/{imageId}", imageId)
+							.session(session))
+					.andExpect(status().isNotFound());
+		}
+
+		@Test
+		@DisplayName("Fail - 삭제하고자 하는 이미지가 이미 삭제되었으면 실패하고 409 응답한다")
+		void deleteImageFailByAlreadyDeleted() throws Exception {
+			// given
+			Member member = new Member("test@test.com", "test", "test");
+			memberRepository.save(member);
+
+			AuthenticationDTO authenticationDTO = new AuthenticationDTO(member.getId(), MemberAuthority.USER);
+			MockHttpSession session = new MockHttpSession();
+			session.setAttribute(LOGIN_MEMBER_INFO, authenticationDTO);
+
+			Image image = new Image(ImageType.REVIEW, 1L, "testUrl", "테스트 이미지.jpg");
+			Image savedImage = imageRepository.save(image);
+			image.delete();
+
+			// when & then
+			mockMvc.perform(delete("/api/v1/images/{imageId}", savedImage.getId())
+							.session(session))
+					.andExpect(status().isConflict());
 		}
 	}
 }

--- a/src/test/java/com/goodseats/seatviewreviews/domain/image/controller/ImageControllerTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/image/controller/ImageControllerTest.java
@@ -1,11 +1,13 @@
 package com.goodseats.seatviewreviews.domain.image.controller;
 
 import static com.goodseats.seatviewreviews.common.security.SessionConstant.*;
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -18,6 +20,8 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goodseats.seatviewreviews.domain.image.model.dto.request.ImageDeleteRequest;
 import com.goodseats.seatviewreviews.domain.image.model.entity.Image;
 import com.goodseats.seatviewreviews.domain.image.model.vo.ImageType;
 import com.goodseats.seatviewreviews.domain.image.repository.ImageRepository;
@@ -33,6 +37,9 @@ class ImageControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
 
 	@Autowired
 	private MemberRepository memberRepository;
@@ -191,5 +198,36 @@ class ImageControllerTest {
 							.session(session))
 					.andExpect(status().isConflict());
 		}
+	}
+
+	@Test
+	@DisplayName("Success - 연관된 이미지들 삭제에 성공하고 204 응답한다")
+	void deleteImagesSuccess() throws Exception {
+		// given
+		Member member = new Member("test@test.com", "test", "test");
+		memberRepository.save(member);
+
+		AuthenticationDTO authenticationDTO = new AuthenticationDTO(member.getId(), MemberAuthority.USER);
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute(LOGIN_MEMBER_INFO, authenticationDTO);
+
+		ImageType imageType = ImageType.REVIEW;
+		Long referenceId = 1L;
+		Image image1 = new Image(imageType, referenceId, "testUrl1", "테스트 이미지1.jpg");
+		Image image2 = new Image(imageType, referenceId, "testUrl2", "테스트 이미지2.jpg");
+		List<Image> images = List.of(image1, image2);
+		imageRepository.saveAll(images);
+
+		ImageDeleteRequest imageDeleteRequest = new ImageDeleteRequest(imageType, referenceId);
+
+		// when
+		mockMvc.perform(delete("/api/v1/images")
+						.session(session)
+						.contentType(APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(imageDeleteRequest)))
+				.andExpect(status().isNoContent());
+
+		// then
+		images.forEach(image -> assertThat(image.getDeletedAt()).isNotNull());
 	}
 }

--- a/src/test/java/com/goodseats/seatviewreviews/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/image/service/ImageServiceTest.java
@@ -5,7 +5,10 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -15,7 +18,10 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.goodseats.seatviewreviews.common.error.exception.DuplicatedException;
+import com.goodseats.seatviewreviews.common.error.exception.NotFoundException;
 import com.goodseats.seatviewreviews.common.file.FileStorageService;
+import com.goodseats.seatviewreviews.domain.image.event.ImageDeleteEvent;
 import com.goodseats.seatviewreviews.domain.image.event.RollbackUploadEvent;
 import com.goodseats.seatviewreviews.domain.image.model.dto.request.ImageCreateRequest;
 import com.goodseats.seatviewreviews.domain.image.model.dto.response.ImageCreateResponse;
@@ -85,5 +91,59 @@ class ImageServiceTest {
 		assertThatThrownBy(() -> imageService.createImage(imageCreateRequest))
 				.isExactlyInstanceOf(IllegalArgumentException.class)
 				.hasMessage(BAD_IMAGE_REQUEST.getMessage());
+	}
+
+	@Test
+	@DisplayName("Success - 이미지 단건 삭제에 성공한다")
+	void deleteImageSuccess() {
+		// given
+		Long imageId=1L;
+		Image image = new Image(ImageType.REVIEW, 1L, "testUrl", "테스트 이미지.jpg");
+		ReflectionTestUtils.setField(image, "id", imageId);
+
+		when(imageRepository.findById(imageId)).thenReturn(Optional.of(image));
+		doNothing().when(applicationEventPublisher).publishEvent(any(ImageDeleteEvent.class));
+
+		// when
+		imageService.deleteImage(imageId);
+
+		// then
+		assertThat(image.getDeletedAt()).isNotNull();
+	}
+
+	@Nested
+	@DisplayName("deleteImageFail")
+	class DeleteImage {
+
+		@Test
+		@DisplayName("Fail - 삭제하고자 하는 이미지가 존재하지 않으면 실패한다")
+		void deleteImageFailByNotFound() {
+			// given
+			Long imageId=1L;
+
+			when(imageRepository.findById(imageId)).thenReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> imageService.deleteImage(imageId))
+					.isExactlyInstanceOf(NotFoundException.class)
+					.hasMessage(NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("Fail - 삭제하고자 하는 이미지가 이미 삭제되었으면 실패한다")
+		void deleteImageFailByAlreadyDeleted() {
+			// given
+			Long imageId=1L;
+			Image image = new Image(ImageType.REVIEW, 1L, "testUrl", "테스트 이미지.jpg");
+			ReflectionTestUtils.setField(image, "id", imageId);
+			image.delete();
+
+			when(imageRepository.findById(imageId)).thenReturn(Optional.of(image));
+
+			// when & then
+			assertThatThrownBy(() -> imageService.deleteImage(imageId))
+					.isExactlyInstanceOf(DuplicatedException.class)
+					.hasMessage(ALREADY_DELETED.getMessage());
+		}
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #79 

### 내용
- 이미지 DB 삭제와 S3 삭제의 생명주기를 맞추기 위한 로직 구현
  - @TransactionalEventListener 사용하여 DB 삭제가 커밋되었을 시 S3 에서 삭제되도록 함
  - S3 삭제 로직은 비동기적으로 처리하여 삭제 응답이 느리지 않도록 함
- BaseEntity 에 delete() 메서드 추가
  - BaseEntity 를 상속하는 엔티티들이 엔티티 삭제 메서드를 갖게하기 위함
- 이미지 단건 삭제 API 구현
  - ex) 사용자가 후기 작성 중에 첨부파일 제거할 때 호출됨
- 연관된 이미지들 삭제 API 구현
  - ex) 후기 삭제, 댓글 삭제 버튼 눌렀을 때 호출됨
- 이미지 단건 삭제 API 관련 테스트 작성
- 연관된 이미지들 삭제 API 관련 테스트 작성