### PR TITLE
Fix: 이미지 생성 API 응답에 이미지 id 도 포함하도록 수정

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/controller/ImageController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/controller/ImageController.java
@@ -3,8 +3,6 @@ package com.goodseats.seatviewreviews.domain.image.controller;
 import static com.goodseats.seatviewreviews.domain.member.model.vo.MemberAuthority.*;
 import static org.springframework.http.MediaType.*;
 
-import java.net.URI;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.goodseats.seatviewreviews.common.security.Authority;
 import com.goodseats.seatviewreviews.domain.image.model.dto.request.ImageCreateRequest;
+import com.goodseats.seatviewreviews.domain.image.model.dto.response.ImageCreateResponse;
 import com.goodseats.seatviewreviews.domain.image.service.ImageService;
 
 import lombok.RequiredArgsConstructor;
@@ -26,8 +25,8 @@ public class ImageController {
 
 	@Authority(authorities = {USER, ADMIN})
 	@PostMapping(consumes = MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
-	public ResponseEntity<Void> createImage(@ModelAttribute ImageCreateRequest imageCreateRequest) {
-		String imageUrl = imageService.createImage(imageCreateRequest);
-		return ResponseEntity.created(URI.create(imageUrl)).build();
+	public ResponseEntity<ImageCreateResponse> createImage(@ModelAttribute ImageCreateRequest imageCreateRequest) {
+		ImageCreateResponse imageCreateResponse = imageService.createImage(imageCreateRequest);
+		return ResponseEntity.ok(imageCreateResponse);
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/model/dto/response/ImageCreateResponse.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/model/dto/response/ImageCreateResponse.java
@@ -1,0 +1,4 @@
+package com.goodseats.seatviewreviews.domain.image.model.dto.response;
+
+public record ImageCreateResponse(Long imageId, String imageUrl) {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/image/service/ImageService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/image/service/ImageService.java
@@ -14,6 +14,7 @@ import com.goodseats.seatviewreviews.common.file.FileStorageService;
 import com.goodseats.seatviewreviews.domain.image.event.RollbackUploadEvent;
 import com.goodseats.seatviewreviews.domain.image.mapper.ImageMapper;
 import com.goodseats.seatviewreviews.domain.image.model.dto.request.ImageCreateRequest;
+import com.goodseats.seatviewreviews.domain.image.model.dto.response.ImageCreateResponse;
 import com.goodseats.seatviewreviews.domain.image.model.entity.Image;
 import com.goodseats.seatviewreviews.domain.image.repository.ImageRepository;
 
@@ -28,7 +29,7 @@ public class ImageService {
 	private final ApplicationEventPublisher applicationEventPublisher;
 
 	@Transactional
-	public String createImage(ImageCreateRequest imageCreateRequest) {
+	public ImageCreateResponse createImage(ImageCreateRequest imageCreateRequest) {
 		if (isNotImage(imageCreateRequest.multipartFile())) {
 			throw new IllegalArgumentException(BAD_IMAGE_REQUEST.getMessage());
 		}
@@ -36,10 +37,11 @@ public class ImageService {
 		String imageUrl = fileStorageService.upload(
 				imageCreateRequest.multipartFile(), imageCreateRequest.imageType().getSubPath()
 		);
+
 		Image image = ImageMapper.toEntity(imageCreateRequest, imageUrl);
 		applicationEventPublisher.publishEvent(new RollbackUploadEvent(image));
 		Image savedImage = imageRepository.save(image);
-		return savedImage.getImageUrl();
+		return new ImageCreateResponse(savedImage.getId(), savedImage.getImageUrl());
 	}
 
 	private boolean isNotImage(MultipartFile multipartFile) {

--- a/src/test/java/com/goodseats/seatviewreviews/domain/image/controller/ImageControllerTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/image/controller/ImageControllerTest.java
@@ -35,7 +35,7 @@ class ImageControllerTest {
 	private MemberRepository memberRepository;
 
 	@Test
-	@DisplayName("Success - 이미지 저장에 성공하고 201 로 응답한다")
+	@DisplayName("Success - 이미지 저장에 성공하고 200 으로 응답한다")
 	void createImageSuccess() throws Exception {
 		// given
 		Member member = new Member("test@test.com", "test", "test");
@@ -59,7 +59,9 @@ class ImageControllerTest {
 						.contentType(MULTIPART_FORM_DATA)
 						.accept(APPLICATION_JSON)
 						.session(session))
-				.andExpect(status().isCreated())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("imageId").isNumber())
+				.andExpect(jsonPath("imageUrl").isString())
 				.andDo(print());
 	}
 

--- a/src/test/java/com/goodseats/seatviewreviews/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/image/service/ImageServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.goodseats.seatviewreviews.common.file.FileStorageService;
 import com.goodseats.seatviewreviews.domain.image.event.RollbackUploadEvent;
 import com.goodseats.seatviewreviews.domain.image.model.dto.request.ImageCreateRequest;
+import com.goodseats.seatviewreviews.domain.image.model.dto.response.ImageCreateResponse;
 import com.goodseats.seatviewreviews.domain.image.model.entity.Image;
 import com.goodseats.seatviewreviews.domain.image.model.vo.ImageType;
 import com.goodseats.seatviewreviews.domain.image.repository.ImageRepository;
@@ -59,13 +60,14 @@ class ImageServiceTest {
 		when(imageRepository.save(any(Image.class))).thenReturn(image);
 
 		// when
-		String savedImageUrl = imageService.createImage(imageCreateRequest);
+		ImageCreateResponse ImageCreateResponse = imageService.createImage(imageCreateRequest);
 
 		// then
 		verify(fileStorageService).upload(imageCreateRequest.multipartFile(), imageCreateRequest.imageType().getSubPath());
 		verify(applicationEventPublisher).publishEvent(any(RollbackUploadEvent.class));
 		verify(imageRepository).save(any(Image.class));
-		assertThat(savedImageUrl).isEqualTo(imageUrl);
+		assertThat(ImageCreateResponse.imageId()).isEqualTo(image.getId());
+		assertThat(ImageCreateResponse.imageUrl()).isEqualTo(image.getImageUrl());
 	}
 
 	@Test


### PR DESCRIPTION
### 관련 이슈
- close #81 

### 내용
- 이미시 생성 API 를 호출했을 시에 그 이미지를 식별할 수 있는 id 가 필요하기에 추가하였음
- 수정사항에 맞게 테스트 코드도 수정함