### PR TITLE
Chore: CI/CD 를 위한 파일들 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,6 +25,9 @@ jobs:
           echo "${{secrets.AWS_ENV}}" >> env/aws.env
           echo "${{secrets.DB_ENV}}" >> env/dev-db.env
 
+      - name: Run docker DB container
+        run: docker-compose -f ./docker/docker-compose.yml up -d db
+
       - name: Get execution permission to gradlew
         run: chmod +x ./gradlew
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,6 +44,8 @@ jobs:
           username: ${{secrets.EC2_USERNAME}}
           key: ${{secrets.EC2_KEY}}
           script: |
-            docker-compose -f ./docker/docker-compose.yml stop
-            docker-compose -f ./docker/docker-compose.yml pull
-            docker-compose -f ./docker/docker-compose.yml up -d
+            scp -r ./env ${{secrets.EC2_USERNAME}}@${{secrets.EC2_HOST}}:~
+            scp docker-compose.yml ${{secrets.EC2_USERNAME}}@${{secrets.EC2_HOST}}:~
+            docker-compose stop
+            docker-compose pull
+            docker-compose up -d

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,49 @@
+name: CD
+
+on:
+  push:
+    branches: [ "develop" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Generate environment file
+        run: |
+          mkdir -p env
+          echo "${{secrets.DOCKER_COMPOSE_ENV}}" >> env/docker-compose.env
+          echo "${{secrets.AWS_ENV}}" >> env/aws.env
+          echo "${{secrets.DB_ENV}}" >> env/dev-db.env
+
+      - name: Get execution permission to gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build
+
+      - name: Build and push docker image
+        run: |
+          docker login -u ${{secrets.DOCKERHUB_USERNAME}} -p ${{secrets.DOCKERHUB_PASSWORD}}
+          docker build -t ${{secrets.DOCKERHUB_USERNAME}}/seat-view-reviews:latest .
+          docker push ${{secrets.DOCKERHUB_USERNAME}}/seat-view-reviews:latest
+
+      - name: Access AWS EC2 and run the app
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{secrets.EC2_HOST}}
+          username: ${{secrets.EC2_USERNAME}}
+          key: ${{secrets.EC2_KEY}}
+          script: |
+            docker-compose -f ./docker/docker-compose.yml stop
+            docker-compose -f ./docker/docker-compose.yml pull
+            docker-compose -f ./docker/docker-compose.yml up -d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           echo "${{secrets.AWS_ENV}}" >> env/aws.env
           echo "${{secrets.DB_ENV}}" >> env/dev-db.env
 
+      - name: Run docker DB container
+        run: docker-compose -f ./docker/docker-compose.yml up -d db
+
       - name: Get execution permission to gradlew
         run: chmod +x ./gradlew
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Generate environment file
+        run: |
+          mkdir -p env
+          echo "${{secrets.DOCKER_COMPOSE_ENV}}" >> env/docker-compose.env
+          echo "${{secrets.AWS_ENV}}" >> env/aws.env
+          echo "${{secrets.DB_ENV}}" >> env/dev-db.env
+
+      - name: Get execution permission to gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM eclipse-temurin:17
+ARG JAR_FILE=build/libs/*jar
+ENV DB_URL=${DB_URL} \
+    DB_USERNAME=${DB_USERNAME} \
+    DB_PASSWORD=${DB_PASSWORD} \
+    ACCESS_KEY=${ACCESS_KEY} \
+    SECRET_KEY=${SECRET_KEY}
+COPY ${JAR_FILE} seat-view-reviews.jar
+ENTRYPOINT ["java", "-jar", "seat-view-reviews.jar"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "3306:3306"
     env_file:
       - ../env/docker-compose.env
-    container_name: seat-view
+    container_name: seat-view-db
     environment:
       TZ: Asia/Seoul
     volumes:
@@ -18,6 +18,21 @@ services:
       - ./sql/jamsil-seat-section.sql:/docker-entrypoint-initdb.d/jamsil-seat-section.sql
       - ./sql/jamsil-seat.sql:/docker-entrypoint-initdb.d/jamsil-seat.sql
     command: bash -c "chmod 644 /etc/mysql/my.cnf && docker-entrypoint.sh mysqld"
+    restart: always
+
+  seat-view-jar:
+    container_name: seat-view-jar
+    image: jeromeeugenemorrow/seat-view-reviews:latest
+    ports:
+      - "8080:8080"
+    environment:
+      DB_URL: ${DB_URL}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      ACCESS_KEY: ${ACCESS_KEY}
+      SECRET_KEY: ${SECRET_KEY}
+    depends_on:
+      - db
     restart: always
 
 volumes:


### PR DESCRIPTION
### 관련 이슈
- close #83 

### 내용
- 프로젝트 빌드 파일을 이미지화하는 Dockerfile 추가
- docker-compose 파일에 Dockerfile 바탕의 컨테이너 추가
- CI 스크립트 추가
- CD 스크립트 추가

### CI/CD 과정 설명
- github actions 를 선택한 이유
  - jenkins 와 github actions 간에 고민을 했지만, jenkins 는 추가적인 설치가 필요하고 github actions 를 이용하면 소스 코드와 함께 github 에서 한번에 관리할 수 있다는 점에서 관리 포인트를 줄이고자 github actions 를 선택하였다.
  - 또한 이미 사용해봤기에 추가적인 러닝 커브도 없다.
- CI/CD 방식으로 빌드 파일을 DockerHub 에 올리고 EC2 에서 pull 받는 방식을 선택한 이유
  - AWS S3 + CodeDeploy 방식, DockerHub + CodeDeploy 방식, DockerHub + EC2 에서 pull 방식 중 고민하였다.
  - 빌드 파일을 DockerHub 에 올리고 EC2 에서 pull 받는 방식을 선택한 이유는 크게 2가지 이유이다. 비용 문제와 AWS 의존성을 낮추기 위함이다.
  - 첫번째 비용 문제는 현재 AWS 프리티어를 이용하고 있는데 S3 가 월별 표준 스토리지 5GB까지, GET 요청 20,000건, PUT 요청 2,000건 무료이다. 생각보다 넉넉한 양은 아니다. 특히 용량 5GB 가 여러 jar 파일을 보관하기에는 부족하다고 생각하였다.
  - 두번째 AWS 의존성을 낮추고자 한 이유는 추후에 온프레미스 환경으로 바꿀 수도 있기 때문이다. 프리티어 혜택이 끝나거나 프리티어 EC2 로 아쉬운 경우에 변경 가능성이 있기에 의존성을 낮추고 싶었다. 