### PR TITLE
Fix: cd 스크립트에 EC2 접속 전후로 보안 그룹에 Github actions 의 IP 를 추가하고 제거해주는 단계 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,6 +41,10 @@ jobs:
           docker build -t ${{secrets.DOCKERHUB_USERNAME}}/seat-view-reviews:latest .
           docker push ${{secrets.DOCKERHUB_USERNAME}}/seat-view-reviews:latest
 
+      - name: Add github actions IP to security group
+        run: |
+          aws ec2 authorize-security-group-ingress --group-name ${{secrets.AWS_SECURITY_GROUP_ID}} --protocol tcp --port 22 --cidr ${{steps.ip.outputs.ipv4}}/32    
+
       - name: Access AWS EC2 and run the app
         uses: appleboy/ssh-action@master
         with:
@@ -53,3 +57,7 @@ jobs:
             docker-compose -f ./docker/docker-compose.yml stop
             docker-compose -f ./docker/docker-compose.yml pull
             docker-compose -f ./docker/docker-compose.yml up -d
+
+      - name: Remove github actions IP from security group
+        run: |
+          aws ec2 revoke-security-group-ingress --group-name ${{secrets.AWS_SECURITY_GROUP_ID}} --protocol tcp --port 22 --cidr ${{steps.ip.outputs.ipv4}}/32


### PR DESCRIPTION
### 관련 이슈
- close #91 

### 내용
- EC2 에 접속 가능한 IP 를 제한하고 있는 상태이므로 보안 그룹에 Github actions 의 IP 를 추가하였음
- EC2 에 접속하여 배포 완료 후에 추가해준 IP 를 제거함