### PR TITLE
Fix: CD 스크립트에서 보안 그룹에 Github actions 의 IP 를 추가하고 제거해주는 명령어 오타 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Add github actions IP to security group
         run: |
-          aws ec2 authorize-security-group-ingress --group-name ${{secrets.AWS_SECURITY_GROUP_ID}} --protocol tcp --port 22 --cidr ${{steps.ip.outputs.ipv4}}/32    
+          aws ec2 authorize-security-group-ingress --group-id ${{secrets.AWS_SECURITY_GROUP_ID}} --protocol tcp --port 22 --cidr ${{steps.ip.outputs.ipv4}}/32    
 
       - name: Access AWS EC2 and run the app
         uses: appleboy/ssh-action@master
@@ -67,4 +67,4 @@ jobs:
 
       - name: Remove github actions IP from security group
         run: |
-          aws ec2 revoke-security-group-ingress --group-name ${{secrets.AWS_SECURITY_GROUP_ID}} --protocol tcp --port 22 --cidr ${{steps.ip.outputs.ipv4}}/32
+          aws ec2 revoke-security-group-ingress --group-id ${{secrets.AWS_SECURITY_GROUP_ID}} --protocol tcp --port 22 --cidr ${{steps.ip.outputs.ipv4}}/32


### PR DESCRIPTION
### 관련 이슈
- close #95