### PR TITLE
Fix: CD 스크립트에서 scp 명령어 대신 appleboy/scp-action@master 사용하도록 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,20 +41,33 @@ jobs:
           docker build -t ${{secrets.DOCKERHUB_USERNAME}}/seat-view-reviews:latest .
           docker push ${{secrets.DOCKERHUB_USERNAME}}/seat-view-reviews:latest
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: ap-northeast-2
-
       - name: Get github actions public IP
         id: ip
         uses: haythem/public-ip@v1.3
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{secrets.AWS_ACCESS_KEY}}
+          aws-secret-access-key: ${{secrets.AWS_SECRET_KEY}}
+          aws-region: ap-northeast-2
+
       - name: Add github actions IP to security group
         run: |
           aws ec2 authorize-security-group-ingress --group-id ${{secrets.AWS_SECURITY_GROUP_ID}} --protocol tcp --port 22 --cidr ${{steps.ip.outputs.ipv4}}/32    
+
+      - name: Send necessary files to EC2
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{secrets.EC2_HOST}}
+          username: ${{secrets.EC2_USERNAME}}
+          key: ${{secrets.EC2_KEY}}
+          port: ${{secrets.EC2_PORT}}
+          source:
+            - "env/*"
+            - "docker/*"
+          strip_components: 0
+          target: "~"
 
       - name: Access AWS EC2 and run the app
         uses: appleboy/ssh-action@master
@@ -62,9 +75,8 @@ jobs:
           host: ${{secrets.EC2_HOST}}
           username: ${{secrets.EC2_USERNAME}}
           key: ${{secrets.EC2_KEY}}
+          port: ${{secrets.EC2_PORT}}
           script: |
-            scp -r ./env ${{secrets.EC2_USERNAME}}@${{secrets.EC2_HOST}}:~
-            scp -r ./docker ${{secrets.EC2_USERNAME}}@${{secrets.EC2_HOST}}:~
             docker-compose -f ./docker/docker-compose.yml stop
             docker-compose -f ./docker/docker-compose.yml pull
             docker-compose -f ./docker/docker-compose.yml up -d


### PR DESCRIPTION
### 관련 이슈
- close #99 

### 내용
- scp 명령어로 파일 또는 폴더를 전송하려면 EC2 접속 password 를 입력해야한다. password 를 입력하지 않으려면 EC2 에 키 파일을 업로드해야한다. 이런 별도의 과정을 워크플로우에 추가하기보다는 appleboy/scp-action@master 를 사용하도록 한다.