### PR TITLE
Fix: docker-compose 로 MySQL 컨테이너 실행 시 기본 데이터 INSERT 작업 안하도록 수정

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,10 +13,6 @@ services:
       - seat-view:/var/lib/mysql
       - ./my.cnf:/etc/mysql/my.cnf
       - ./sql/init.sql:/docker-entrypoint-initdb.d/init.sql
-      - ./sql/stadium.sql:/docker-entrypoint-initdb.d/stadium.sql
-      - ./sql/jamsil-seat-grade.sql:/docker-entrypoint-initdb.d/jamsil-seat-grade.sql
-      - ./sql/jamsil-seat-section.sql:/docker-entrypoint-initdb.d/jamsil-seat-section.sql
-      - ./sql/jamsil-seat.sql:/docker-entrypoint-initdb.d/jamsil-seat.sql
     command: bash -c "chmod 644 /etc/mysql/my.cnf && docker-entrypoint.sh mysqld"
     restart: always
 


### PR DESCRIPTION
### 관련 내용
- close #103 

### 내용
- CD 과정에서 매번 필요한 기본 데이터를 INSERT 하기보다는 미리 MySQL 에 넣어놓는 것이 효율적임