### PR TITLE
Feat: 조회 수 중복 방지를 위한 쿠키 로직 구현

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/common/constant/CookieConstant.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/constant/CookieConstant.java
@@ -1,0 +1,10 @@
+package com.goodseats.seatviewreviews.common.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CookieConstant {
+
+	public static final String USER_KEY = "USER_KEY";
+}

--- a/src/main/java/com/goodseats/seatviewreviews/common/util/CookieUtils.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/util/CookieUtils.java
@@ -1,0 +1,34 @@
+package com.goodseats.seatviewreviews.common.util;
+
+import static com.goodseats.seatviewreviews.common.constant.CookieConstant.*;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CookieUtils {
+
+	private static final int DAY = 60 * 60 * 24;
+
+	public static Cookie setUserKey(Cookie userKey, HttpServletResponse response) {
+		if (Objects.nonNull(userKey)) {
+			return userKey;
+		}
+
+		userKey = new Cookie(USER_KEY, String.valueOf(UUID.randomUUID()));
+		userKey.setPath("/");
+		userKey.setMaxAge(DAY);
+		userKey.setSecure(true);
+		userKey.setHttpOnly(true);
+
+		response.addCookie(userKey);
+
+		return userKey;
+	}
+}


### PR DESCRIPTION
### 관련 이슈
- close #109 

### 내용
- 조회 수 정책
  - 그 날의 인기 글 작성자에게 포인트 제공, 조회수 순 정렬과 같은 기능이 추후에 추가 예정
  - 포인트와 관련되므로 조회 수가 신뢰성을 갖게 중복을 방지하고 싶었음

- 조회 수 중복 방지
  - 1안: IP 를 통해 중복 방지
    - 장점
      - 사용자가 조작이 불가능
    - 단점
      - 공용 IP 를 사용하면 여러 사람이 한 사람으로 취급됨
      - 한 사람이 다른 장소로 이동하여 다른 IP 이용하면 다른 사람 취급됨
      - IP 저장해도 되는 지의 여부
  - 2안: 세션에서 유저 식별자_게시글 id 형식으로 저장
    - 단점
      - 조회 수 특성 상 서버가 너무 많은 부담을 가짐
  - 3안:  게시글 id 를 쿠키로 하여 중복 방지
    - 장점
      - 서버가 별도로 저장할 필요 없음
    - 단점
      -  사용자가 쿠키 삭제하여 조작 가능함
      - 쿠키 갯수에 한계가 있음. ex) 도메인 당 20개, 브라우저 300개 등
  - 결론
    - 세션과 쿠키의 문제점을 보완하여 쿠키로는 사용자를 식별하고, 데이터는 Redis 에 저장하는 방식
    - Redis 를 도입하는 것이 부담일 수 있지만 동시성 문제까지 고려하여 도입하기로 함 