### PR TITLE
Add: 도커 컨테이너의 로그 설정 추가

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,6 +14,11 @@ services:
       - ./my.cnf:/etc/mysql/my.cnf
       - ./sql/init.sql:/docker-entrypoint-initdb.d/init.sql
     command: bash -c "chmod 644 /etc/mysql/my.cnf && docker-entrypoint.sh mysqld"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     restart: always
 
   redis:
@@ -27,8 +32,13 @@ services:
       TZ: Asia/Seoul
     volumes:
       - seat-view:/data
-    restart: always
     command: redis-server
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: always
 
   seat-view-jar:
     container_name: seat-view-jar
@@ -44,6 +54,11 @@ services:
     depends_on:
       - db
       - redis
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     restart: always
 
 volumes:


### PR DESCRIPTION
### 관련 이슈
- close #112 

### 내용
- 도커 컨테이너의 기본 로깅 드라이버인 json-file 은 기본 로그 파일 용량이 무제한이고 파일 회전도 하지 않음
- 로그 파일 용량과 회전에 관한 설정을 docker-compose 파일에 추가함 