### PR TITLE
Fix: CI/CD 시 Github actions 서버에서 테스트를 위한 redis env 파일 분리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,7 +26,8 @@ jobs:
           echo "${{secrets.AWS_ENV}}" >> env/aws.env
           echo "${{secrets.TEST_DB_ENV}}" >> env/test-db.env
           echo "${{secrets.DEV_DB_ENV}}" >> env/dev-db.env
-          echo "${{secrets.REDIS_ENV}}" >> env/redis.env
+          echo "${{secrets.TEST_REDIS_ENV}}" >> env/test-redis.env
+          echo "${{secrets.DEV_REDIS_ENV}}" >> env/dev-redis.env
 
       - name: Run docker DB, Redis container
         run: | 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
           echo "${{secrets.AWS_ENV}}" >> env/aws.env
           echo "${{secrets.TEST_DB_ENV}}" >> env/test-db.env
           echo "${{secrets.DEV_DB_ENV}}" >> env/dev-db.env
-          echo "${{secrets.REDIS_ENV}}" >> env/redis.env
+          echo "${{secrets.TEST_REDIS_ENV}}" >> env/test-redis.env
+          echo "${{secrets.DEV_REDIS_ENV}}" >> env/dev-redis.env
 
       - name: Run docker DB, Redis container
         run: | 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,7 +26,8 @@ services:
     ports:
       - "6379:6379"
     env_file:
-      - ../env/redis.env
+      - ../env/dev-redis.env
+      - ../env/test-redis.env
     container_name: seat-view-redis
     environment:
       TZ: Asia/Seoul
@@ -48,7 +49,7 @@ services:
     env_file:
       - ../env/dev-db.env
       - ../env/aws.env
-      - ../env/redis.env
+      - ../env/dev-redis.env
     environment:
       TZ: Asia/Seoul
     depends_on:

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -2,7 +2,7 @@ spring:
   config:
     import:
       - optional:file:env/dev-db.env[.properties]
-      - optional:file:env/redis.env[.properties]
+      - optional:file:env/dev-redis.env[.properties]
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -2,7 +2,7 @@ spring:
   config:
     import:
       - optional:file:env/test-db.env[.properties]
-      - optional:file:env/redis.env[.properties]
+      - optional:file:env/test-redis.env[.properties]
     activate:
       on-profile: test
 


### PR DESCRIPTION
### 관련 이슈
- close #119 

### 주요 내용
- CI/CD 시 Github actions 서버에서 빌드 과정에서 테스트할 때, redis 가 필요하다. 이 때 redis host 를 다르게 하기 위해 env 파일을 분리한다.