### PR TITLE
Feat: 후기 조회 수 스케줄링 로직 구현

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/SeatViewReviewsApplication.java
+++ b/src/main/java/com/goodseats/seatviewreviews/SeatViewReviewsApplication.java
@@ -3,8 +3,10 @@ package com.goodseats.seatviewreviews;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableAsync
+@EnableScheduling
 @SpringBootApplication
 public class SeatViewReviewsApplication {
 

--- a/src/main/java/com/goodseats/seatviewreviews/common/constant/SchedulerConstant.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/constant/SchedulerConstant.java
@@ -1,0 +1,10 @@
+package com.goodseats.seatviewreviews.common.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SchedulerConstant {
+
+	public static final int VIEW_COUNT_SCHEDULING_MINUTE = 5;
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/scheduler/ReviewScheduler.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/scheduler/ReviewScheduler.java
@@ -1,0 +1,99 @@
+package com.goodseats.seatviewreviews.domain.review.scheduler;
+
+import static com.goodseats.seatviewreviews.common.constant.RedisConstant.*;
+import static com.goodseats.seatviewreviews.common.constant.SchedulerConstant.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.redisson.api.RMap;
+import org.redisson.api.RedissonClient;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goodseats.seatviewreviews.common.error.exception.ErrorCode;
+import com.goodseats.seatviewreviews.common.error.exception.NotFoundException;
+import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
+import com.goodseats.seatviewreviews.domain.review.repository.ReviewRepository;
+import com.goodseats.seatviewreviews.domain.review.service.ReviewRedisFacade;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewScheduler {
+
+	private final ReviewRedisFacade reviewRedisFacade;
+	private final RedissonClient redissonClient;
+	private final ReviewRepository reviewRepository;
+
+	@Transactional
+	@Scheduled(cron = "0 */5 * * * *")
+	public void syncViewCountToDB() {
+		RMap<String, String> reviewAndViewCountLogs = redissonClient.getMap(REVIEW_AND_VIEW_COUNT_LOGS_NAME);
+		String previousScheduledMinute = getPreviousScheduledMinute();
+		List<String> targetKeys = getTargetsToSync(previousScheduledMinute, reviewAndViewCountLogs);
+		updateViewCount(reviewAndViewCountLogs, targetKeys);
+	}
+
+	@Scheduled(cron = "0 0 0 * * *")
+	public void clearHitLogs() {
+		reviewRedisFacade.clearAllLogs();
+	}
+
+	private String getPreviousScheduledMinute() {
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime previousScheduledMinute = now.minusMinutes(VIEW_COUNT_SCHEDULING_MINUTE);
+		return previousScheduledMinute.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+	}
+
+	private List<String> getTargetsToSync(String previousScheduledMinute, RMap<String, String> reviewAndViewCountLogs) {
+		return reviewAndViewCountLogs.keySet().stream()
+				.filter(key -> isTargetToSync(previousScheduledMinute, key))
+				.collect(Collectors.toMap(
+						this::extractReviewId,
+						Function.identity(),
+						BinaryOperator.maxBy(Comparator.comparing(this::extractViewedTime))
+				))
+				.values()
+				.stream()
+				.toList();
+	}
+
+	private boolean isTargetToSync(String previousScheduledMinute, String key) {
+		int beforeViewedTimeIndex = key.lastIndexOf(DELIMITER);
+		String viewedTime = key.substring(beforeViewedTimeIndex + 1);
+		return viewedTime.compareTo(previousScheduledMinute) >= 0;
+	}
+
+	private String extractReviewId(String key) {
+		int beforeReviewIdIndex = key.indexOf(DELIMITER);
+		int afterReviewIdIndex = key.indexOf(SEPARATOR);
+		return key.substring(beforeReviewIdIndex + 1, afterReviewIdIndex);
+	}
+
+	private LocalDateTime extractViewedTime(String key) {
+		int beforeTimeIndex = key.lastIndexOf(DELIMITER);
+		String timeString = key.substring(beforeTimeIndex + 1);
+		return LocalDateTime.parse(timeString, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+	}
+
+	private void updateViewCount(RMap<String, String> reviewAndViewCountLogs, List<String> targetKeys) {
+		targetKeys
+				.forEach(key -> {
+					int viewCount = Integer.parseInt(reviewAndViewCountLogs.get(key));
+					Long reviewId = Long.valueOf(extractReviewId(key));
+
+					Review review = reviewRepository.findById(reviewId)
+							.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND));
+
+					review.updateViewCount(viewCount);
+				});
+	}
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/scheduler/ReviewScheduler.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/scheduler/ReviewScheduler.java
@@ -43,7 +43,7 @@ public class ReviewScheduler {
 	}
 
 	@Scheduled(cron = "0 0 0 * * *")
-	public void clearHitLogs() {
+	public void clearViewCountLogs() {
 		reviewRedisFacade.clearAllLogs();
 	}
 

--- a/src/test/java/com/goodseats/seatviewreviews/domain/review/scheduler/ReviewSchedulerTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/review/scheduler/ReviewSchedulerTest.java
@@ -1,0 +1,136 @@
+package com.goodseats.seatviewreviews.domain.review.scheduler;
+
+import static com.goodseats.seatviewreviews.common.constant.RedisConstant.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RMap;
+import org.redisson.api.RedissonClient;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.goodseats.seatviewreviews.common.error.exception.ErrorCode;
+import com.goodseats.seatviewreviews.common.error.exception.NotFoundException;
+import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
+import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
+import com.goodseats.seatviewreviews.domain.review.repository.ReviewRepository;
+import com.goodseats.seatviewreviews.domain.review.service.ReviewRedisFacade;
+import com.goodseats.seatviewreviews.domain.seat.model.entity.Seat;
+import com.goodseats.seatviewreviews.domain.seat.model.entity.SeatGrade;
+import com.goodseats.seatviewreviews.domain.seat.model.entity.SeatSection;
+import com.goodseats.seatviewreviews.domain.stadium.model.entity.Stadium;
+import com.goodseats.seatviewreviews.domain.stadium.model.vo.HomeTeam;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewSchedulerTest {
+
+	@Mock
+	private ReviewRedisFacade reviewRedisFacade;
+
+	@Mock
+	private RedissonClient redissonClient;
+
+	@Mock
+	private ReviewRepository reviewRepository;
+
+	@Mock
+	private RMap<Object, Object> reviewAndViewCountLogs;
+
+	@InjectMocks
+	private ReviewScheduler reviewScheduler;
+
+	@Test
+	@DisplayName("Success - 스케줄링 주기마다 redis 에 저장된 조회 수를 DB 에 동기화한다")
+	void syncViewCountToDBSuccess() {
+		// given
+		Long seatId = 1L;
+		Long memberId = 1L;
+		Long reviewId = 1L;
+
+		Member member = new Member("test@test.com", "test", "test");
+		ReflectionTestUtils.setField(member, "id", memberId);
+
+		Stadium stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
+		SeatGrade seatGrade = new SeatGrade("테이블", "주중 47,000 / 주말 53,000", stadium);
+		SeatSection seatSection = new SeatSection("110", stadium, seatGrade);
+		Seat seat = new Seat("1", seatGrade, seatSection);
+		ReflectionTestUtils.setField(seat, "id", seatId);
+
+		Review review = new Review("테스트 제목", "테스트 내용", 5, member, seat);
+		ReflectionTestUtils.setField(review, "id", reviewId);
+
+		String nowTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+		String key = "reviewId" + "_" + reviewId + ", " + "viewedTime" + "_" + nowTime;
+		Set<Object> keySet = new HashSet<>();
+		keySet.add(key);
+
+		String latestViewCount = "100";
+
+		when(redissonClient.getMap(REVIEW_AND_VIEW_COUNT_LOGS_NAME)).thenReturn(reviewAndViewCountLogs);
+		when(reviewAndViewCountLogs.keySet()).thenReturn(keySet);
+		when(reviewAndViewCountLogs.get(key)).thenReturn(latestViewCount);
+		when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(review));
+
+		// when
+		reviewScheduler.syncViewCountToDB();
+
+		// then
+		verify(redissonClient).getMap(REVIEW_AND_VIEW_COUNT_LOGS_NAME);
+		verify(reviewAndViewCountLogs).keySet();
+		verify(reviewAndViewCountLogs).get(key);
+		verify(reviewRepository).findById(reviewId);
+		assertThat(review.getViewCount()).isEqualTo(Integer.parseInt(latestViewCount));
+	}
+
+	@Test
+	@DisplayName("Fail - redis 에 저장된 후기가 DB 에 없으면 동기화에 실패한다")
+	void syncViewCountToDBFailByNotFoundReview() {
+		// given
+		Long reviewId = 1L;
+
+		String nowTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+		String key = "reviewId" + "_" + reviewId + ", " + "viewedTime" + "_" + nowTime;
+		Set<Object> keySet = new HashSet<>();
+		keySet.add(key);
+
+		String latestViewCount = "100";
+
+		when(redissonClient.getMap(REVIEW_AND_VIEW_COUNT_LOGS_NAME)).thenReturn(reviewAndViewCountLogs);
+		when(reviewAndViewCountLogs.keySet()).thenReturn(keySet);
+		when(reviewAndViewCountLogs.get(key)).thenReturn(latestViewCount);
+		when(reviewRepository.findById(reviewId)).thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> reviewScheduler.syncViewCountToDB())
+				.isExactlyInstanceOf(NotFoundException.class)
+				.hasMessage(ErrorCode.NOT_FOUND.getMessage());
+		verify(redissonClient).getMap(REVIEW_AND_VIEW_COUNT_LOGS_NAME);
+		verify(reviewAndViewCountLogs).keySet();
+		verify(reviewAndViewCountLogs).get(key);
+		verify(reviewRepository).findById(reviewId);
+	}
+
+	@Test
+	@DisplayName("Success - 스케줄링 주기마다 redis 에 저장된 조회 수 데이터를 제거한다")
+	void clearViewCountLogsSuccess() {
+		// given
+		doNothing().when(reviewRedisFacade).clearAllLogs();
+
+		// when
+		reviewScheduler.clearViewCountLogs();
+
+		// then
+		verify(reviewRedisFacade).clearAllLogs();
+	}
+}


### PR DESCRIPTION
### 관련 이슈
- close #121 

### 주요 내용
- 조회 수 배치 처리
  - DB 에 부하가 많이 갈 것으로 예상하여 실시간으로 DB 에 조회 수를 반영하지 않음
    - 특히, 사용자가 F5 계속 누르고 있는 경우와 같이 악의적인 공격을 예방하기 위함
  - 조회 수는 실시간성도 중요한 값이기에 5분마다 조회 수를 업데이트 해줌
  - Redis 에 저장된 데이터는 인기 글 산정 주기인 하루마다 제거

- 스케줄링 로직 테스트 작성
  - 스케줄링 동작 자체는 Spring 의 동작이므로 테스트하지 않음
  - 스케줄러 메서드 호출 시 의도한 대로 동작하는지 Mockito 이용하여 테스트함