### PR TITLE
Feat: 후기 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/controller/ReviewController.java
@@ -10,6 +10,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.SessionAttribute;
 
@@ -30,6 +32,7 @@ import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
 import com.goodseats.seatviewreviews.domain.review.model.dto.request.ReviewPublishRequest;
 import com.goodseats.seatviewreviews.domain.review.model.dto.request.TempReviewCreateRequest;
 import com.goodseats.seatviewreviews.domain.review.model.dto.response.ReviewDetailResponse;
+import com.goodseats.seatviewreviews.domain.review.model.dto.response.ReviewsResponse;
 import com.goodseats.seatviewreviews.domain.review.service.ReviewRedisFacade;
 import com.goodseats.seatviewreviews.domain.review.service.ReviewService;
 
@@ -74,5 +77,11 @@ public class ReviewController {
 		userKey = CookieUtils.setUserKey(userKey, response);
 		ReviewDetailResponse reviewDetailResponse = reviewRedisFacade.getReview(userKey.getValue(), reviewId);
 		return ResponseEntity.ok(reviewDetailResponse);
+	}
+
+	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<ReviewsResponse> getReviews(@RequestParam Long seatId, Pageable pageable) {
+		ReviewsResponse reviewsResponse = reviewService.getReviews(seatId, pageable);
+		return ResponseEntity.ok(reviewsResponse);
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/mapper/ReviewMapper.java
@@ -1,7 +1,13 @@
 package com.goodseats.seatviewreviews.domain.review.mapper;
 
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+
 import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
 import com.goodseats.seatviewreviews.domain.review.model.dto.response.ReviewDetailResponse;
+import com.goodseats.seatviewreviews.domain.review.model.dto.response.ReviewsElementResponse;
+import com.goodseats.seatviewreviews.domain.review.model.dto.response.ReviewsResponse;
 import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
 import com.goodseats.seatviewreviews.domain.seat.model.entity.Seat;
 
@@ -17,7 +23,22 @@ public class ReviewMapper {
 
 	public static ReviewDetailResponse toReviewDetailResponse(Review review) {
 		return new ReviewDetailResponse(
-				review.getTitle(), review.getContent(), review.getScore(), review.getViewCount(), review.getMember().getNickname()
+				review.getTitle(), review.getContent(), review.getScore(), review.getViewCount(),
+				review.getMember().getNickname()
+		);
+	}
+
+	public static ReviewsElementResponse toReviewsElementResponse(Review review) {
+		return new ReviewsElementResponse(
+				review.getTitle(), review.getScore(), review.getViewCount(), review.getMember().getNickname()
+		);
+	}
+
+	public static ReviewsResponse toReviewsResponse(Page<Review> reviewPage) {
+		return new ReviewsResponse(
+				reviewPage.map(ReviewMapper::toReviewsElementResponse)
+						.stream()
+						.collect(Collectors.toList())
 		);
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/mapper/ReviewMapper.java
@@ -30,7 +30,7 @@ public class ReviewMapper {
 
 	public static ReviewsElementResponse toReviewsElementResponse(Review review) {
 		return new ReviewsElementResponse(
-				review.getTitle(), review.getScore(), review.getViewCount(), review.getMember().getNickname()
+				review.getId(), review.getTitle(), review.getScore(), review.getViewCount(), review.getMember().getNickname()
 		);
 	}
 

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/model/dto/response/ReviewsElementResponse.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/model/dto/response/ReviewsElementResponse.java
@@ -1,4 +1,4 @@
 package com.goodseats.seatviewreviews.domain.review.model.dto.response;
 
-public record ReviewsElementResponse(String title, int score, int viewCount, String writer) {
+public record ReviewsElementResponse(Long reviewId, String title, int score, int viewCount, String writer) {
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/model/dto/response/ReviewsElementResponse.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/model/dto/response/ReviewsElementResponse.java
@@ -1,0 +1,4 @@
+package com.goodseats.seatviewreviews.domain.review.model.dto.response;
+
+public record ReviewsElementResponse(String title, int score, int viewCount, String writer) {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/model/dto/response/ReviewsResponse.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/model/dto/response/ReviewsResponse.java
@@ -1,0 +1,6 @@
+package com.goodseats.seatviewreviews.domain.review.model.dto.response;
+
+import java.util.List;
+
+public record ReviewsResponse(List<ReviewsElementResponse> reviews) {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/repository/ReviewRepository.java
@@ -3,11 +3,14 @@ package com.goodseats.seatviewreviews.domain.review.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
-import com.goodseats.seatviewreviews.domain.seat.model.entity.Seat;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-	Page<Review> findAllBySeatAndPublishedTrue(Seat seat, Pageable pageable);
+	@Query(value = "SELECT r FROM Review r JOIN FETCH r.member WHERE r.seat.id = :seatId AND r.published IS TRUE",
+			countQuery ="SELECT count(r) FROM Review r WHERE r.seat.id = :seatId AND r.published IS TRUE" )
+	Page<Review> findAllWithFetchMemberBySeatIdAndPublishedTrue(@Param("seatId") Long seatId, Pageable pageable);
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/repository/ReviewRepository.java
@@ -1,8 +1,13 @@
 package com.goodseats.seatviewreviews.domain.review.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
+import com.goodseats.seatviewreviews.domain.seat.model.entity.Seat;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+	Page<Review> findAllBySeatAndPublishedTrue(Seat seat, Pageable pageable);
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/service/ReviewService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/service/ReviewService.java
@@ -2,6 +2,8 @@ package com.goodseats.seatviewreviews.domain.review.service;
 
 import static com.goodseats.seatviewreviews.common.error.exception.ErrorCode.*;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +14,7 @@ import com.goodseats.seatviewreviews.domain.review.mapper.ReviewMapper;
 import com.goodseats.seatviewreviews.domain.review.model.dto.request.ReviewPublishRequest;
 import com.goodseats.seatviewreviews.domain.review.model.dto.request.TempReviewCreateRequest;
 import com.goodseats.seatviewreviews.domain.review.model.dto.response.ReviewDetailResponse;
+import com.goodseats.seatviewreviews.domain.review.model.dto.response.ReviewsResponse;
 import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
 import com.goodseats.seatviewreviews.domain.review.repository.ReviewRepository;
 import com.goodseats.seatviewreviews.domain.seat.model.entity.Seat;
@@ -54,5 +57,14 @@ public class ReviewService {
 				.orElseThrow(() -> new NotFoundException(NOT_FOUND));
 
 		return ReviewMapper.toReviewDetailResponse(review);
+	}
+
+	@Transactional(readOnly = true)
+	public ReviewsResponse getReviews(Long seatId, Pageable pageable) {
+		Seat seat = seatRepository.findById(seatId)
+				.orElseThrow(() -> new NotFoundException(NOT_FOUND));
+
+		Page<Review> reviewPage = reviewRepository.findAllBySeatAndPublishedTrue(seat, pageable);
+		return ReviewMapper.toReviewsResponse(reviewPage);
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/service/ReviewService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/service/ReviewService.java
@@ -64,7 +64,7 @@ public class ReviewService {
 		Seat seat = seatRepository.findById(seatId)
 				.orElseThrow(() -> new NotFoundException(NOT_FOUND));
 
-		Page<Review> reviewPage = reviewRepository.findAllBySeatAndPublishedTrue(seat, pageable);
+		Page<Review> reviewPage = reviewRepository.findAllWithFetchMemberBySeatIdAndPublishedTrue(seat.getId(), pageable);
 		return ReviewMapper.toReviewsResponse(reviewPage);
 	}
 }

--- a/src/test/java/com/goodseats/seatviewreviews/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/review/service/ReviewServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -46,63 +47,64 @@ class ReviewServiceTest {
 	@InjectMocks
 	private ReviewService reviewService;
 
+	private Member member;
+	private Stadium stadium;
+	private SeatGrade seatGrade;
+	private SeatSection seatSection;
+	private Seat seat;
+	private Review tempReview;
+	private Review publishedReview;
+
+	@BeforeEach
+	void setUp() {
+		member = new Member("test@test.com", "test", "test");
+		stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
+		seatGrade = new SeatGrade("테이블", "주중 47,000 / 주말 53,000", stadium);
+		seatSection = new SeatSection("110", stadium, seatGrade);
+		seat = new Seat("1", seatGrade, seatSection);
+		tempReview = new Review(member, seat);
+		publishedReview = new Review("테스트 제목", "테스트 내용", 5, member, seat);
+
+		ReflectionTestUtils.setField(member, "id", 1L);
+		ReflectionTestUtils.setField(stadium, "id", 1L);
+		ReflectionTestUtils.setField(seatGrade, "id", 1L);
+		ReflectionTestUtils.setField(seatSection, "id", 1L);
+		ReflectionTestUtils.setField(seat, "id", 1L);
+		ReflectionTestUtils.setField(tempReview, "id", 1L);
+		ReflectionTestUtils.setField(publishedReview, "id", 1L);
+	}
+
 	@Test
 	@DisplayName("Success - 후기 임시 생성에 성공한다")
 	void createTempReviewSuccess() {
 		// given
-		Long seatId = 1L;
-		Long memberId = 1L;
-		Long reviewId = 1L;
-		TempReviewCreateRequest tempReviewCreateRequest = new TempReviewCreateRequest(seatId);
+		TempReviewCreateRequest tempReviewCreateRequest = new TempReviewCreateRequest(seat.getId());
 
-		Member member = new Member("test@test.com", "test", "test");
-		ReflectionTestUtils.setField(member, "id", memberId);
-
-		Stadium stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
-		SeatGrade seatGrade = new SeatGrade("테이블", "주중 47,000 / 주말 53,000", stadium);
-		SeatSection seatSection = new SeatSection("110", stadium, seatGrade);
-		Seat seat = new Seat("1", seatGrade, seatSection);
-		ReflectionTestUtils.setField(seat, "id", seatId);
-
-		Review review = new Review(member, seat);
-		ReflectionTestUtils.setField(review, "id", reviewId);
-
-		when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-		when(seatRepository.findById(seatId)).thenReturn(Optional.of(seat));
-		when(reviewRepository.save(any(Review.class))).thenReturn(review);
+		when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+		when(seatRepository.findById(seat.getId())).thenReturn(Optional.of(seat));
+		when(reviewRepository.save(any(Review.class))).thenReturn(tempReview);
 
 		// when
-		Long savedReviewId = reviewService.createTempReview(tempReviewCreateRequest, memberId);
+		Long savedReviewId = reviewService.createTempReview(tempReviewCreateRequest, member.getId());
 
 		// then
-		verify(memberRepository).findById(memberId);
-		verify(seatRepository).findById(seatId);
+		verify(memberRepository).findById(member.getId());
+		verify(seatRepository).findById(seat.getId());
 		verify(reviewRepository).save(any(Review.class));
-		assertThat(savedReviewId).isEqualTo(review.getId());
+		assertThat(savedReviewId).isEqualTo(tempReview.getId());
 	}
 
 	@Test
 	@DisplayName("Fail - 후기 작성 하려는 좌석의 id 가 없으면 실패한다")
 	void createTempReviewFailByNotFoundSeatId() {
 		// given
-		Long seatId = 1L;
-		Long memberId = 1L;
-		TempReviewCreateRequest tempReviewCreateRequest = new TempReviewCreateRequest(seatId);
+		TempReviewCreateRequest tempReviewCreateRequest = new TempReviewCreateRequest(seat.getId());
 
-		Member member = new Member("test@test.com", "test", "test");
-		ReflectionTestUtils.setField(member, "id", memberId);
-
-		Stadium stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
-		SeatGrade seatGrade = new SeatGrade("테이블", "주중 47,000 / 주말 53,000", stadium);
-		SeatSection seatSection = new SeatSection("110", stadium, seatGrade);
-		Seat seat = new Seat("1", seatGrade, seatSection);
-		ReflectionTestUtils.setField(seat, "id", seatId);
-
-		when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-		when(seatRepository.findById(seatId)).thenReturn(Optional.empty());
+		when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+		when(seatRepository.findById(seat.getId())).thenReturn(Optional.empty());
 
 		// when & then
-		assertThatThrownBy(() -> reviewService.createTempReview(tempReviewCreateRequest, memberId))
+		assertThatThrownBy(() -> reviewService.createTempReview(tempReviewCreateRequest, member.getId()))
 				.isExactlyInstanceOf(NotFoundException.class)
 				.hasMessage(NOT_FOUND.getMessage());
 	}
@@ -111,27 +113,12 @@ class ReviewServiceTest {
 	@DisplayName("Success - 후기 발행에 성공한다")
 	void publishReviewSuccess() {
 		// given
-		Long seatId = 1L;
-		Long memberId = 1L;
-		Long reviewId = 1L;
 		ReviewPublishRequest reviewPublishRequest = new ReviewPublishRequest("테스트 제목", "테스트 내용", 5);
 
-		Member member = new Member("test@test.com", "test", "test");
-		ReflectionTestUtils.setField(member, "id", memberId);
-
-		Stadium stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
-		SeatGrade seatGrade = new SeatGrade("테이블", "주중 47,000 / 주말 53,000", stadium);
-		SeatSection seatSection = new SeatSection("110", stadium, seatGrade);
-		Seat seat = new Seat("1", seatGrade, seatSection);
-		ReflectionTestUtils.setField(seat, "id", seatId);
-
-		Review tempReview = new Review(member, seat);
-		ReflectionTestUtils.setField(tempReview, "id", reviewId);
-
-		when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(tempReview));
+		when(reviewRepository.findById(tempReview.getId())).thenReturn(Optional.of(tempReview));
 
 		// when
-		reviewService.publishReview(reviewPublishRequest, reviewId, memberId);
+		reviewService.publishReview(reviewPublishRequest, tempReview.getId(), member.getId());
 
 		// then
 		assertThat(tempReview.getTitle()).isEqualTo(reviewPublishRequest.title());
@@ -147,14 +134,12 @@ class ReviewServiceTest {
 		@DisplayName("Fail - 발행하고자 하는 임시 후기가 존재하지 않으면 실패한다")
 		void publishReviewFailByNotFoundTempReview() {
 			// given
-			Long memberId = 1L;
-			Long reviewId = 1L;
 			ReviewPublishRequest reviewPublishRequest = new ReviewPublishRequest("테스트 제목", "테스트 내용", 5);
 
-			when(reviewRepository.findById(reviewId)).thenReturn(Optional.empty());
+			when(reviewRepository.findById(tempReview.getId())).thenReturn(Optional.empty());
 
 			// when & then
-			assertThatThrownBy(() -> reviewService.publishReview(reviewPublishRequest, reviewId, memberId))
+			assertThatThrownBy(() -> reviewService.publishReview(reviewPublishRequest, tempReview.getId(), member.getId()))
 					.isExactlyInstanceOf(NotFoundException.class)
 					.hasMessage(NOT_FOUND.getMessage());
 		}
@@ -162,28 +147,13 @@ class ReviewServiceTest {
 		@Test
 		@DisplayName("Fail - 발행하는 회원이 임시 후기를 작성한 회원이 아니면 실패한다")
 		void publishReviewFailByNotTempReviewWriter() {
-			Long seatId = 1L;
-			Long memberId = 1L;
 			Long wrongMemberId = 2L;
-			Long reviewId = 1L;
 			ReviewPublishRequest reviewPublishRequest = new ReviewPublishRequest("테스트 제목", "테스트 내용", 5);
 
-			Member member = new Member("test@test.com", "test", "test");
-			ReflectionTestUtils.setField(member, "id", memberId);
-
-			Stadium stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
-			SeatGrade seatGrade = new SeatGrade("테이블", "주중 47,000 / 주말 53,000", stadium);
-			SeatSection seatSection = new SeatSection("110", stadium, seatGrade);
-			Seat seat = new Seat("1", seatGrade, seatSection);
-			ReflectionTestUtils.setField(seat, "id", seatId);
-
-			Review tempReview = new Review(member, seat);
-			ReflectionTestUtils.setField(tempReview, "id", reviewId);
-
-			when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(tempReview));
+			when(reviewRepository.findById(tempReview.getId())).thenReturn(Optional.of(tempReview));
 
 			// when & then
-			assertThatThrownBy(() -> reviewService.publishReview(reviewPublishRequest, reviewId, wrongMemberId))
+			assertThatThrownBy(() -> reviewService.publishReview(reviewPublishRequest, tempReview.getId(), wrongMemberId))
 					.isExactlyInstanceOf(AuthenticationException.class)
 					.hasMessage(UNAUTHORIZED.getMessage());
 		}
@@ -193,57 +163,28 @@ class ReviewServiceTest {
 	@DisplayName("Success - 후기 상세 조회에 성공한다")
 	void getReviewSuccess() {
 		// given
-		Long seatId = 1L;
-		Long memberId = 1L;
-		Long reviewId = 1L;
-
-		Member member = new Member("test@test.com", "test", "test");
-		ReflectionTestUtils.setField(member, "id", memberId);
-
-		Stadium stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
-		SeatGrade seatGrade = new SeatGrade("테이블", "주중 47,000 / 주말 53,000", stadium);
-		SeatSection seatSection = new SeatSection("110", stadium, seatGrade);
-		Seat seat = new Seat("1", seatGrade, seatSection);
-		ReflectionTestUtils.setField(seat, "id", seatId);
-
-		Review review = new Review("테스트 제목", "테스트 내용", 5, member, seat);
-		ReflectionTestUtils.setField(review, "id", reviewId);
-
-		when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(review));
+		when(reviewRepository.findById(publishedReview.getId())).thenReturn(Optional.of(publishedReview));
 
 		// when
-		ReviewDetailResponse reviewDetailResponse = reviewService.getReview(reviewId);
+		ReviewDetailResponse reviewDetailResponse = reviewService.getReview(publishedReview.getId());
 
 		// then
-		verify(reviewRepository).findById(reviewId);
-		assertThat(reviewDetailResponse.title()).isEqualTo(review.getTitle());
-		assertThat(reviewDetailResponse.content()).isEqualTo(review.getContent());
-		assertThat(reviewDetailResponse.viewCount()).isEqualTo(review.getViewCount());
-		assertThat(reviewDetailResponse.score()).isEqualTo(review.getScore());
-		assertThat(reviewDetailResponse.writer()).isEqualTo(review.getMember().getNickname());
+		verify(reviewRepository).findById(publishedReview.getId());
+		assertThat(reviewDetailResponse.title()).isEqualTo(publishedReview.getTitle());
+		assertThat(reviewDetailResponse.content()).isEqualTo(publishedReview.getContent());
+		assertThat(reviewDetailResponse.viewCount()).isEqualTo(publishedReview.getViewCount());
+		assertThat(reviewDetailResponse.score()).isEqualTo(publishedReview.getScore());
+		assertThat(reviewDetailResponse.writer()).isEqualTo(publishedReview.getMember().getNickname());
 	}
 
 	@Test
 	@DisplayName("Fail - 조회하려는 후기가 없으면 후기 상세 조회에 실패한다")
 	void getReviewFailByNotFound() {
 		// given
-		Long seatId = 1L;
-		Long memberId = 1L;
-		Long reviewId = 1L;
-
-		Member member = new Member("test@test.com", "test", "test");
-		ReflectionTestUtils.setField(member, "id", memberId);
-
-		Stadium stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
-		SeatGrade seatGrade = new SeatGrade("테이블", "주중 47,000 / 주말 53,000", stadium);
-		SeatSection seatSection = new SeatSection("110", stadium, seatGrade);
-		Seat seat = new Seat("1", seatGrade, seatSection);
-		ReflectionTestUtils.setField(seat, "id", seatId);
-
-		when(reviewRepository.findById(reviewId)).thenReturn(Optional.empty());
+		when(reviewRepository.findById(publishedReview.getId())).thenReturn(Optional.empty());
 
 		// when & then
-		assertThatThrownBy(() -> reviewService.getReview(reviewId))
+		assertThatThrownBy(() -> reviewService.getReview(publishedReview.getId()))
 				.isExactlyInstanceOf(NotFoundException.class)
 				.hasMessage(NOT_FOUND.getMessage());
 	}


### PR DESCRIPTION
### 관련 이슈
- close #123 

### 내용
- 후기 목록 조회 시 오프셋 기반 페이지네이션으로 조회하도록 함
  - 좌석의 후기를 볼 때는 커서 기반의 무한 스크롤보다 여러 후기가 한 번에 보이는 전통적인 오프셋 기반이 좋다고 판단함