### PR TITLE
Fix: 후기 엔티티의 제목, 내용, 평점을 publish 메서드 통해서만 입력할 수 있도록 함

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/common/error/exception/ErrorCode.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
 	UNAUTHORIZED(401, "인증되지 않은 사용자입니다."),
 	BAD_LOGIN_REQUEST(400, "아이디 혹은 비밀번호가 틀립니다."),
 	BAD_IMAGE_REQUEST(400, "잘못된 이미지 업로드 요청입니다."),
-	ALREADY_DELETED(409, "이미 삭제된 데이터입니다.");
+	ALREADY_DELETED(409, "이미 삭제된 데이터입니다."),
+	ALREADY_PUBLISHED(409, "이미 발행된 후기입니다.");
 
 	private final int status;
 	private final String message;

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/model/entity/Review.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/model/entity/Review.java
@@ -11,6 +11,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import com.goodseats.seatviewreviews.common.error.exception.AuthenticationException;
+import com.goodseats.seatviewreviews.common.error.exception.DuplicatedException;
 import com.goodseats.seatviewreviews.common.error.exception.ErrorCode;
 import com.goodseats.seatviewreviews.domain.BaseEntity;
 import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
@@ -53,16 +54,6 @@ public class Review extends BaseEntity {
 	@JoinColumn(name = "seat_id")
 	private Seat seat;
 
-	public Review(String title, String content, int score, Member member, Seat seat) {
-		this.title = title;
-		this.content = content;
-		this.score = score;
-		this.viewCount = 0;
-		this.published = false;
-		this.member = member;
-		this.seat = seat;
-	}
-
 	public Review(Member member, Seat seat) {
 		this.viewCount = 0;
 		this.published = false;
@@ -71,6 +62,10 @@ public class Review extends BaseEntity {
 	}
 
 	public void publish(String title, String content, int score) {
+		if (this.published) {
+			throw new DuplicatedException(ErrorCode.ALREADY_PUBLISHED);
+		}
+
 		this.title = title;
 		this.content = content;
 		this.score = score;

--- a/src/test/java/com/goodseats/seatviewreviews/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/review/controller/ReviewControllerTest.java
@@ -46,7 +46,6 @@ import com.goodseats.seatviewreviews.domain.stadium.model.vo.HomeTeam;
 import com.goodseats.seatviewreviews.domain.stadium.repository.StadiumRepository;
 
 @ActiveProfiles("test")
-// @Transactional
 @SpringBootTest
 @AutoConfigureMockMvc
 class ReviewControllerTest {
@@ -96,7 +95,8 @@ class ReviewControllerTest {
 		seatSection = new SeatSection("110", stadium, seatGrade);
 		seat = new Seat("1", seatGrade, seatSection);
 		tempReview = new Review(writer, seat);
-		publishedReview = new Review("테스트 제목", "테스트 내용", 5, writer, seat);
+		publishedReview = new Review(writer, seat);
+		publishedReview.publish("테스트 제목", "테스트 내용", 5);
 
 		memberRepository.save(writer);
 		memberRepository.save(notWriter);

--- a/src/test/java/com/goodseats/seatviewreviews/domain/review/scheduler/ReviewSchedulerTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/review/scheduler/ReviewSchedulerTest.java
@@ -67,7 +67,8 @@ class ReviewSchedulerTest {
 		Seat seat = new Seat("1", seatGrade, seatSection);
 		ReflectionTestUtils.setField(seat, "id", seatId);
 
-		Review review = new Review("테스트 제목", "테스트 내용", 5, member, seat);
+		Review review = new Review(member, seat);
+		review.publish("테스트 제목", "테스트 내용", 5);
 		ReflectionTestUtils.setField(review, "id", reviewId);
 
 		String nowTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));


### PR DESCRIPTION
### 관련 이슈
- close #130 

### 내용
- 후기 엔티티에서 제목, 내용, 평점을 포함한 생성자를 없애어 publish 메서드를 통해서만 입력할 수 있도록 함.
  - 서비스에서는 임시 후기 -> 발행의 과정을 거쳐야지만 후기에 제목, 내용, 평점이 생기기에 코드 레벨에서도 동일하게 하여 잘못된 상태의 후기를 미연에 방지함.