### PR TITLE
Fix: 조회 수 분실 방지를 위한 Lock 사용 시 wait time, lease time 늘림

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/common/constant/RedisConstant.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/constant/RedisConstant.java
@@ -12,7 +12,7 @@ public class RedisConstant {
 	public static final String DELIMITER = "_";
 	public static final String SEPARATOR = ", ";
 	public static final String LOCK_NAME = "viewCountLock";
-	public static final int LOCK_WAIT_TIME = 2;
-	public static final int LEASE_TIME = 1;
+	public static final int LOCK_WAIT_TIME = 10;
+	public static final int LEASE_TIME = 5;
 
 }


### PR DESCRIPTION
### 관련 이슈
- close #132 

### 내용
- 락 사용 시 wait time 이 2초로 충분치 않아 100명 이상이 동시에 몰렸을 시 락 획득을 하지 못하여 예외가 발생함. 이를 방지하고자 시간을 10초로 늘림.