### PR TITLE
Docs: adoc 파일에서 doctype 제거

### DIFF
--- a/src/docs/asciidoc/rest-docs.adoc
+++ b/src/docs/asciidoc/rest-docs.adoc
@@ -3,11 +3,10 @@ ifndef::snippets[]
 endif::[]
 
 = 야구장 좌석 후기 서비스
-:doctype: book
-:icons: font
-:source-highlighter: highlightjs
 :toc: left
 :toclevels: 3
+:icons: font
+:source-highlighter: highlightjs
 :sectlinks:
 
 == 1. 경기장


### PR DESCRIPTION
### 관련 이슈
- close #149 

### 내용
- doctype 이 book 인 경우 toclevels 가 0 밖에 안되어 목차 생성이 안되므로 doctype 를 제거함