### PR TITLE
Fix: GlobalExceptionHandler 에서 warn, error 레벨의 예외를 info 로 찍고 있던 것 수정

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/common/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/error/handler/GlobalExceptionHandler.java
@@ -273,10 +273,10 @@ public class GlobalExceptionHandler {
 	}
 
 	private void logWarn(Exception e, String url) {
-		log.info("URL = {}, Exception = {}, Message = {}", url, e.getClass().getSimpleName(), e.getMessage());
+		log.warn("URL = {}, Exception = {}, Message = {}", url, e.getClass().getSimpleName(), e.getMessage());
 	}
 
 	private void logError(Exception e, String url) {
-		log.info("URL = {}, Exception = {}, Message = {}", url, e.getClass().getSimpleName(), e.getMessage());
+		log.error("URL = {}, Exception = {}, Message = {}", url, e.getClass().getSimpleName(), e.getMessage());
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #157 