### PR TITLE
Fix: 조회 수 동시성 로직 수정

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/service/ReviewRedisFacade.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/service/ReviewRedisFacade.java
@@ -12,7 +12,6 @@ import org.redisson.api.RMap;
 import org.redisson.api.RSet;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.goodseats.seatviewreviews.domain.review.model.dto.response.ReviewDetailResponse;
 
@@ -25,7 +24,6 @@ public class ReviewRedisFacade {
 	private final RedissonClient redissonClient;
 	private final ReviewService reviewService;
 
-	@Transactional(readOnly = true)
 	public ReviewDetailResponse getReview(String userKey, Long reviewId) {
 		if (hasNotViewedReview(userKey, reviewId)) {
 			controlViewCountConcurrency(userKey, reviewId);
@@ -70,7 +68,9 @@ public class ReviewRedisFacade {
 		} catch (InterruptedException e) {
 			throw new RuntimeException(e);
 		} finally {
-			viewCountLock.unlock();
+			if (viewCountLock.isHeldByCurrentThread()) {
+				viewCountLock.unlock();
+			}
 		}
 	}
 


### PR DESCRIPTION
### 관련 이슈
- close #159 

### 내용
- redis 락 해제 시 현재 스레드가 락을 가지고 있는 여부를 확인하도록 함
  - 그렇지 않으면 현재 스레드에서 다른 스레드의 락을 해제할 수 있음
- ReviewRedisFacade 의 후기 상세 조회 메서드에서 @transactional 제거