### PR TITLE
Fix: AuthenticationInterceptor 에서 유저 정보를 DB 에 확인하는 단계 제거

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/common/config/WebConfig.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/config/WebConfig.java
@@ -5,7 +5,6 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.goodseats.seatviewreviews.common.security.AuthenticationInterceptor;
-import com.goodseats.seatviewreviews.domain.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,11 +12,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-	private final MemberRepository memberRepository;
-
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
-		registry.addInterceptor(new AuthenticationInterceptor(memberRepository))
+		registry.addInterceptor(new AuthenticationInterceptor())
 				.addPathPatterns("/api/**");
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/common/security/AuthenticationInterceptor.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/security/AuthenticationInterceptor.java
@@ -15,14 +15,11 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 import com.goodseats.seatviewreviews.common.error.exception.AuthenticationException;
 import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
-import com.goodseats.seatviewreviews.domain.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class AuthenticationInterceptor implements HandlerInterceptor {
-
-	private final MemberRepository memberRepository;
 
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
@@ -47,9 +44,6 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 	}
 
 	private boolean checkAuthority(Authority authorityAnnotation, AuthenticationDTO authenticationDTO) {
-		if (isMemberInvalid(authenticationDTO.memberId())) {
-			throw new AuthenticationException(UNAUTHORIZED);
-		}
 
 		boolean hasAuthority = Arrays.stream(authorityAnnotation.authorities())
 				.anyMatch(authority -> authority.equals(authenticationDTO.memberAuthority()));
@@ -58,9 +52,5 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 		}
 
 		throw new AuthenticationException(UNAUTHORIZED);
-	}
-
-	private boolean isMemberInvalid(Long memberId) {
-		return !memberRepository.existsByIdAndDeletedAtIsNull(memberId);
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #165 

### 내용
- 로그인이 필요한 매 요청마다 DB 에 확인할 필요가 없다. 세션의 유저 정보 유무로 인증/인가를 판별하는 것이 옳다.