### PR TITLE
Feat: 후기 투표 조회 API 구현

### DIFF
--- a/docker/sql/init.sql
+++ b/docker/sql/init.sql
@@ -78,6 +78,8 @@ CREATE TABLE IF NOT EXISTS `review`
     `score`           INT            NULL,
     `view_count`      INT            NOT NULL,
     `published`       BOOLEAN        NOT NULL,
+    `like_count`      INT            NOT NULL,
+    `dislike_count`   INT            NOT NULL,
     `created_at`      TIMESTAMP      NOT NULL,
     `last_updated_at` TIMESTAMP      NOT NULL,
     `deleted_at`      TIMESTAMP      NULL

--- a/src/docs/asciidoc/rest-docs.adoc
+++ b/src/docs/asciidoc/rest-docs.adoc
@@ -422,6 +422,7 @@ include::{snippets}/후기 투표 삭제 성공/path-parameters.adoc[]
 include::{snippets}/후기 투표 삭제 성공/http-response.adoc[]
 
 ==== 실패 - 후기 투표 id 없는 경우
+===== Request
 include::{snippets}/후기 투표 삭제 실패 - 후기 투표 id 없는 경우/http-request.adoc[]
 ===== Path Parameters
 include::{snippets}/후기 투표 삭제 실패 - 후기 투표 id 없는 경우/path-parameters.adoc[]
@@ -431,6 +432,7 @@ include::{snippets}/후기 투표 삭제 실패 - 후기 투표 id 없는 경우
 include::{snippets}/후기 투표 삭제 실패 - 후기 투표 id 없는 경우/response-fields.adoc[]
 
 ==== 실패 - 후기 투표자가 아닌 경우
+===== Request
 include::{snippets}/후기 투표 삭제 실패 - 후기 투표자가 아닌 경우/http-request.adoc[]
 ===== Path Parameters
 include::{snippets}/후기 투표 삭제 실패 - 후기 투표자가 아닌 경우/path-parameters.adoc[]
@@ -438,3 +440,24 @@ include::{snippets}/후기 투표 삭제 실패 - 후기 투표자가 아닌 경
 include::{snippets}/후기 투표 삭제 실패 - 후기 투표자가 아닌 경우/http-response.adoc[]
 ===== Response Fields
 include::{snippets}/후기 투표 삭제 실패 - 후기 투표자가 아닌 경우/response-fields.adoc[]
+
+=== 6-3. 후기 투표 조회
+==== 성공
+===== Request
+include::{snippets}/후기 투표 조회 성공/http-request.adoc[]
+===== Request Parameters
+include::{snippets}/후기 투표 조회 성공/request-parameters.adoc[]
+===== Response
+include::{snippets}/후기 투표 조회 성공/http-response.adoc[]
+===== Response Fields
+include::{snippets}/후기 투표 조회 성공/response-fields.adoc[]
+
+==== 실패 - 연관된 후기가 없는 경우
+===== Request
+include::{snippets}/후기 투표 조회 실패 - 연관된 후기가 없는 경우/http-request.adoc[]
+===== Request Parameters
+include::{snippets}/후기 투표 조회 실패 - 연관된 후기가 없는 경우/request-parameters.adoc[]
+===== Response
+include::{snippets}/후기 투표 조회 실패 - 연관된 후기가 없는 경우/http-response.adoc[]
+===== Response Fields
+include::{snippets}/후기 투표 조회 실패 - 연관된 후기가 없는 경우/response-fields.adoc[]

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/model/entity/Review.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/model/entity/Review.java
@@ -16,6 +16,7 @@ import com.goodseats.seatviewreviews.common.error.exception.ErrorCode;
 import com.goodseats.seatviewreviews.domain.BaseEntity;
 import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
 import com.goodseats.seatviewreviews.domain.seat.model.entity.Seat;
+import com.goodseats.seatviewreviews.domain.vote.model.vo.VoteChoice;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -46,6 +47,12 @@ public class Review extends BaseEntity {
 	@Column(name = "published", nullable = false)
 	private boolean published;
 
+	@Column(name = "like_count", nullable = false)
+	private int likeCount;
+
+	@Column(name = "dislike_count", nullable = false)
+	private int dislikeCount;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member member;
@@ -59,6 +66,8 @@ public class Review extends BaseEntity {
 		this.published = false;
 		this.member = member;
 		this.seat = seat;
+		this.likeCount = 0;
+		this.dislikeCount = 0;
 	}
 
 	public void publish(String title, String content, int score) {
@@ -80,5 +89,12 @@ public class Review extends BaseEntity {
 
 	public void updateViewCount(int viewCount) {
 		this.viewCount = viewCount;
+	}
+
+	public void updateVoteCount(int voteCount, VoteChoice voteChoice) {
+		switch (voteChoice) {
+			case LIKE -> this.likeCount=voteCount;
+			case DISLIKE -> this.dislikeCount=voteCount;
+		}
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/controller/ReviewVoteController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/controller/ReviewVoteController.java
@@ -4,6 +4,7 @@ import static com.goodseats.seatviewreviews.common.security.SessionConstant.*;
 import static com.goodseats.seatviewreviews.domain.member.model.vo.MemberAuthority.*;
 
 import java.net.URI;
+import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.SessionAttribute;
 import com.goodseats.seatviewreviews.common.security.Authority;
 import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
 import com.goodseats.seatviewreviews.domain.vote.model.dto.request.ReviewVoteCreateRequest;
+import com.goodseats.seatviewreviews.domain.vote.model.dto.request.ReviewVotesGetRequest;
 import com.goodseats.seatviewreviews.domain.vote.model.dto.response.ReviewVotesResponse;
 import com.goodseats.seatviewreviews.domain.vote.service.ReviewVoteService;
 
@@ -57,8 +59,14 @@ public class ReviewVoteController {
 	}
 
 	@GetMapping
-	ResponseEntity<ReviewVotesResponse> getVotes(@RequestParam Long reviewId) {
-		ReviewVotesResponse reviewVotesResponse = reviewVoteService.getVotes(reviewId);
+	ResponseEntity<ReviewVotesResponse> getVotes(
+			@RequestParam Long reviewId,
+			@SessionAttribute(value = LOGIN_MEMBER_INFO, required = false) AuthenticationDTO authenticationDTO
+	) {
+		ReviewVotesGetRequest reviewVotesGetRequest = new ReviewVotesGetRequest(
+				reviewId, Optional.ofNullable(authenticationDTO)
+		);
+		ReviewVotesResponse reviewVotesResponse = reviewVoteService.getVotes(reviewVotesGetRequest);
 		return ResponseEntity.ok(reviewVotesResponse);
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/controller/ReviewVoteController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/controller/ReviewVoteController.java
@@ -12,15 +12,18 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.SessionAttribute;
 
 import com.goodseats.seatviewreviews.common.security.Authority;
 import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
 import com.goodseats.seatviewreviews.domain.vote.model.dto.request.ReviewVoteCreateRequest;
+import com.goodseats.seatviewreviews.domain.vote.model.dto.response.ReviewVotesResponse;
 import com.goodseats.seatviewreviews.domain.vote.service.ReviewVoteService;
 
 import lombok.RequiredArgsConstructor;
@@ -51,5 +54,11 @@ public class ReviewVoteController {
 	) {
 		reviewVoteService.deleteVote(reviewVoteId, authenticationDTO.memberId());
 		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping
+	ResponseEntity<ReviewVotesResponse> getVotes(@RequestParam Long reviewId) {
+		ReviewVotesResponse reviewVotesResponse = reviewVoteService.getVotes(reviewId);
+		return ResponseEntity.ok(reviewVotesResponse);
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/mapper/ReviewVoteMapper.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/mapper/ReviewVoteMapper.java
@@ -2,6 +2,7 @@ package com.goodseats.seatviewreviews.domain.vote.mapper;
 
 import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
 import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
+import com.goodseats.seatviewreviews.domain.vote.model.dto.response.ReviewVotesResponse;
 import com.goodseats.seatviewreviews.domain.vote.model.entity.ReviewVote;
 import com.goodseats.seatviewreviews.domain.vote.model.vo.VoteChoice;
 
@@ -13,5 +14,17 @@ public class ReviewVoteMapper {
 
 	public static ReviewVote toEntity(Member member, Review review, VoteChoice voteChoice) {
 		return new ReviewVote(voteChoice, member, review);
+	}
+
+	public static ReviewVotesResponse toClickedReviewVotesResponse(Review review, ReviewVote reviewVote) {
+		return new ReviewVotesResponse(
+				review.getLikeCount(), review.getDislikeCount(), reviewVote.isLike(), reviewVote.isDislike()
+		);
+	}
+
+	public static ReviewVotesResponse toNotClickedReviewVotesResponse(Review review) {
+		return new ReviewVotesResponse(
+				review.getLikeCount(), review.getDislikeCount(), false, false
+		);
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/model/dto/request/ReviewVotesGetRequest.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/model/dto/request/ReviewVotesGetRequest.java
@@ -1,0 +1,8 @@
+package com.goodseats.seatviewreviews.domain.vote.model.dto.request;
+
+import java.util.Optional;
+
+import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
+
+public record ReviewVotesGetRequest(Long reviewId, Optional<AuthenticationDTO> authenticationDTO) {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/model/dto/response/ReviewVotesResponse.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/model/dto/response/ReviewVotesResponse.java
@@ -1,4 +1,9 @@
 package com.goodseats.seatviewreviews.domain.vote.model.dto.response;
 
-public record ReviewVotesResponse(int likeCount, int dislikeCount) {
+public record ReviewVotesResponse(
+		int likeCount,
+		int dislikeCount,
+		boolean clickLike,
+		boolean clickDislike
+) {
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/model/dto/response/ReviewVotesResponse.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/model/dto/response/ReviewVotesResponse.java
@@ -1,0 +1,4 @@
+package com.goodseats.seatviewreviews.domain.vote.model.dto.response;
+
+public record ReviewVotesResponse(int likeCount, int dislikeCount) {
+}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/model/entity/ReviewVote.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/model/entity/ReviewVote.java
@@ -1,5 +1,7 @@
 package com.goodseats.seatviewreviews.domain.vote.model.entity;
 
+import static com.goodseats.seatviewreviews.domain.vote.model.vo.VoteChoice.*;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -55,5 +57,13 @@ public class ReviewVote extends BaseEntity {
 		if (!this.member.getId().equals(memberId)) {
 			throw new AuthenticationException(ErrorCode.UNAUTHORIZED);
 		}
+	}
+
+	public boolean isLike() {
+		return this.voteChoice == LIKE;
+	}
+
+	public boolean isDislike() {
+		return this.voteChoice == DISLIKE;
 	}
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/repository/ReviewVoteRepository.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/repository/ReviewVoteRepository.java
@@ -5,8 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
 import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
 import com.goodseats.seatviewreviews.domain.vote.model.entity.ReviewVote;
+import com.goodseats.seatviewreviews.domain.vote.model.vo.VoteChoice;
 
 public interface ReviewVoteRepository extends JpaRepository<ReviewVote, Long> {
 
 	boolean existsByMemberAndReview(Member member, Review review);
+
+	int countReviewVoteByReviewAndVoteChoice(Review review, VoteChoice voteChoice);
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/repository/ReviewVoteRepository.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/repository/ReviewVoteRepository.java
@@ -5,11 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
 import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
 import com.goodseats.seatviewreviews.domain.vote.model.entity.ReviewVote;
-import com.goodseats.seatviewreviews.domain.vote.model.vo.VoteChoice;
 
 public interface ReviewVoteRepository extends JpaRepository<ReviewVote, Long> {
 
 	boolean existsByMemberAndReview(Member member, Review review);
-
-	int countReviewVoteByReviewAndVoteChoice(Review review, VoteChoice voteChoice);
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/repository/ReviewVoteRepository.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/repository/ReviewVoteRepository.java
@@ -1,5 +1,7 @@
 package com.goodseats.seatviewreviews.domain.vote.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
@@ -9,4 +11,6 @@ import com.goodseats.seatviewreviews.domain.vote.model.entity.ReviewVote;
 public interface ReviewVoteRepository extends JpaRepository<ReviewVote, Long> {
 
 	boolean existsByMemberAndReview(Member member, Review review);
+
+	Optional<ReviewVote> findReviewVoteByMemberAndReview(Member member, Review review);
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/service/ReviewVoteService.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/service/ReviewVoteService.java
@@ -1,6 +1,7 @@
 package com.goodseats.seatviewreviews.domain.vote.service;
 
 import static com.goodseats.seatviewreviews.common.error.exception.ErrorCode.*;
+import static com.goodseats.seatviewreviews.domain.vote.model.vo.VoteChoice.*;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +14,7 @@ import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
 import com.goodseats.seatviewreviews.domain.review.repository.ReviewRepository;
 import com.goodseats.seatviewreviews.domain.vote.mapper.ReviewVoteMapper;
 import com.goodseats.seatviewreviews.domain.vote.model.dto.request.ReviewVoteCreateRequest;
+import com.goodseats.seatviewreviews.domain.vote.model.dto.response.ReviewVotesResponse;
 import com.goodseats.seatviewreviews.domain.vote.model.entity.ReviewVote;
 import com.goodseats.seatviewreviews.domain.vote.repository.ReviewVoteRepository;
 
@@ -40,7 +42,7 @@ public class ReviewVoteService {
 		ReviewVote reviewVote = ReviewVoteMapper.toEntity(member, review, reviewVoteCreateRequest.voteChoice());
 		reviewVoteRepository.save(reviewVote);
 
-		return review.getId();
+		return reviewVote.getId();
 	}
 
 	@Transactional
@@ -50,5 +52,16 @@ public class ReviewVoteService {
 		reviewVote.verifyVoter(memberId);
 
 		reviewVoteRepository.delete(reviewVote);
+	}
+
+	@Transactional(readOnly = true)
+	public ReviewVotesResponse getVotes(Long reviewId) {
+		Review review = reviewRepository.findById(reviewId)
+				.orElseThrow(() -> new NotFoundException(NOT_FOUND));
+
+		int likeCount = reviewVoteRepository.countReviewVoteByReviewAndVoteChoice(review, LIKE);
+		int dislikeCount = reviewVoteRepository.countReviewVoteByReviewAndVoteChoice(review, DISLIKE);
+
+		return new ReviewVotesResponse(likeCount, dislikeCount);
 	}
 }

--- a/src/main/resources/static/docs/rest-docs.html
+++ b/src/main/resources/static/docs/rest-docs.html
@@ -564,6 +564,12 @@
               <li><a href="#_실패_후기_투표자가_아닌_경우">실패 - 후기 투표자가 아닌 경우</a></li>
             </ul>
           </li>
+          <li><a href="#_6_3_후기_투표_조회">6-3. 후기 투표 조회</a>
+            <ul class="sectlevel3">
+              <li><a href="#_성공_17">성공</a></li>
+              <li><a href="#_실패_연관된_후기가_없는_경우">실패 - 연관된 후기가 없는 경우</a></li>
+            </ul>
+          </li>
         </ul>
       </li>
     </ul>
@@ -614,7 +620,7 @@ Host: localhost:8080</code></pre>
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 1578
+Content-Length: 2257
 
 {
   "stadiums" : [ {
@@ -674,11 +680,39 @@ Content-Length: 1578
     "name" : "잠실 야구장",
     "homeTeam" : "DOOSAN_LG"
   }, {
-    "stadiumId" : 2782,
+    "stadiumId" : 2801,
     "name" : "잠실 야구장",
     "homeTeam" : "DOOSAN_LG"
   }, {
-    "stadiumId" : 2783,
+    "stadiumId" : 2838,
+    "name" : "잠실 야구장",
+    "homeTeam" : "DOOSAN_LG"
+  }, {
+    "stadiumId" : 2842,
+    "name" : "잠실 야구장",
+    "homeTeam" : "DOOSAN_LG"
+  }, {
+    "stadiumId" : 2843,
+    "name" : "잠실 야구장",
+    "homeTeam" : "DOOSAN_LG"
+  }, {
+    "stadiumId" : 2845,
+    "name" : "잠실 야구장",
+    "homeTeam" : "DOOSAN_LG"
+  }, {
+    "stadiumId" : 2855,
+    "name" : "잠실 야구장",
+    "homeTeam" : "DOOSAN_LG"
+  }, {
+    "stadiumId" : 2857,
+    "name" : "잠실 야구장",
+    "homeTeam" : "DOOSAN_LG"
+  }, {
+    "stadiumId" : 2938,
+    "name" : "잠실 야구장",
+    "homeTeam" : "DOOSAN_LG"
+  }, {
+    "stadiumId" : 2939,
     "name" : "한화생명 이글스 파크",
     "homeTeam" : "HANWHA"
   } ]
@@ -735,7 +769,7 @@ Content-Length: 1578
             <h5 id="_request_2"><a class="link" href="#_request_2">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/stadiums/2781 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/stadiums/2937 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -897,7 +931,7 @@ Content-Length: 221
   "url" : "/api/v1/stadiums/-1",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-07 02:37:38",
+  "createdAt" : "2023-08-21 22:23:40",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -967,7 +1001,7 @@ Content-Length: 221
             <h5 id="_request_4"><a class="link" href="#_request_4">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/sections?stadiumId=2796 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/sections?stadiumId=2952 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -1025,10 +1059,10 @@ Content-Length: 147
 
 {
   "seatSections" : [ {
-    "sectionId" : 2572,
+    "sectionId" : 2722,
     "sectionName" : "110"
   }, {
-    "sectionId" : 2573,
+    "sectionId" : 2723,
     "sectionName" : "111"
   } ]
 }</code></pre>
@@ -1079,7 +1113,7 @@ Content-Length: 147
             <h5 id="_request_5"><a class="link" href="#_request_5">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/seats?sectionId=2574 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/seats?sectionId=2724 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -1259,7 +1293,7 @@ loginEmail=goodseat%40google.com&amp;password=password&amp;nickname=Jerome</code
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Location: /api/v1/members/6305</code></pre>
+Location: /api/v1/members/1016640</code></pre>
               </div>
             </div>
           </div>
@@ -1341,7 +1375,7 @@ Content-Length: 209
   "url" : "/api/v1/members",
   "exceptionName" : "DuplicatedException",
   "message" : "중복된 아이디입니다.",
-  "createdAt" : "2023-08-07 02:37:56",
+  "createdAt" : "2023-08-21 22:23:59",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -1474,7 +1508,7 @@ Content-Length: 209
   "url" : "/api/v1/members",
   "exceptionName" : "DuplicatedException",
   "message" : "중복된 아이디입니다.",
-  "createdAt" : "2023-08-07 02:37:56",
+  "createdAt" : "2023-08-21 22:23:59",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -1675,7 +1709,7 @@ Content-Length: 236
   "url" : "/api/v1/members/login",
   "exceptionName" : "AuthenticationException",
   "message" : "아이디 혹은 비밀번호가 틀립니다.",
-  "createdAt" : "2023-08-07 02:37:56",
+  "createdAt" : "2023-08-21 22:23:58",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -1804,7 +1838,7 @@ Content-Length: 236
   "url" : "/api/v1/members/login",
   "exceptionName" : "AuthenticationException",
   "message" : "아이디 혹은 비밀번호가 틀립니다.",
-  "createdAt" : "2023-08-07 02:37:56",
+  "createdAt" : "2023-08-21 22:23:59",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -1907,7 +1941,7 @@ Content-Length: 230
   "url" : "/api/v1/members/logout",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-07 02:37:56",
+  "createdAt" : "2023-08-21 22:23:58",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2079,8 +2113,8 @@ Content-Type: application/json
 Content-Length: 149
 
 {
-  "imageId" : 800,
-  "imageUrl" : "https://seat-view-reviews.s3.ap-northeast-2.amazonaws.com/reviews/178d5c25-f7a0-4db3-a80e-d3351bf10453.png"
+  "imageId" : 815,
+  "imageUrl" : "https://seat-view-reviews.s3.ap-northeast-2.amazonaws.com/reviews/eba19dab-0c17-4af5-8e6f-56e55e269424.png"
 }</code></pre>
               </div>
             </div>
@@ -2227,7 +2261,7 @@ Content-Length: 222
   "url" : "/api/v1/images",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-07 02:37:58",
+  "createdAt" : "2023-08-21 22:24:00",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2395,7 +2429,7 @@ Content-Length: 230
   "url" : "/api/v1/images",
   "exceptionName" : "IllegalArgumentException",
   "message" : "잘못된 이미지 업로드 요청입니다.",
-  "createdAt" : "2023-08-07 02:37:57",
+  "createdAt" : "2023-08-21 22:24:00",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2540,7 +2574,7 @@ Host: localhost:8080
             <h5 id="_request_18"><a class="link" href="#_request_18">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/images/801 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/images/816 HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
@@ -2622,7 +2656,7 @@ Content-Length: 218
   "url" : "/api/v1/images/1",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-07 02:37:57",
+  "createdAt" : "2023-08-21 22:24:00",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2684,7 +2718,7 @@ Content-Length: 218
             <h5 id="_request_20"><a class="link" href="#_request_20">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/images/802 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/images/817 HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
@@ -2721,10 +2755,10 @@ Content-Length: 219
 
 {
   "status" : 409,
-  "url" : "/api/v1/images/802",
+  "url" : "/api/v1/images/817",
   "exceptionName" : "DuplicatedException",
   "message" : "이미 삭제된 데이터입니다.",
-  "createdAt" : "2023-08-07 02:37:57",
+  "createdAt" : "2023-08-21 22:24:00",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2801,7 +2835,7 @@ Content-Length: 24
 Host: localhost:8080
 
 {
-  "seatId" : 26690
+  "seatId" : 26837
 }</code></pre>
               </div>
             </div>
@@ -2860,7 +2894,7 @@ Host: localhost:8080
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Location: /api/v1/reviews/4102</code></pre>
+Location: /api/v1/reviews/70</code></pre>
               </div>
             </div>
           </div>
@@ -2945,7 +2979,7 @@ Content-Length: 217
   "url" : "/api/v1/reviews",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-07 02:37:52",
+  "createdAt" : "2023-08-21 22:23:55",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3010,7 +3044,7 @@ Content-Length: 217
             <h5 id="_request_23"><a class="link" href="#_request_23">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/reviews/4111 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/reviews/79 HTTP/1.1
 Content-Type: application/x-www-form-urlencoded;charset=UTF-8
 Host: localhost:8080</code></pre>
               </div>
@@ -3191,7 +3225,7 @@ Content-Length: 219
   "url" : "/api/v1/reviews/1",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-07 02:37:55",
+  "createdAt" : "2023-08-21 22:23:57",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3334,14 +3368,14 @@ Host: localhost:8080</code></pre>
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
 Content-Type: application/json
-Content-Length: 228
+Content-Length: 226
 
 {
   "status" : 401,
-  "url" : "/api/v1/reviews/4123",
+  "url" : "/api/v1/reviews/91",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-07 02:37:55",
+  "createdAt" : "2023-08-21 22:23:57",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3406,7 +3440,7 @@ Content-Length: 228
             <h5 id="_request_24"><a class="link" href="#_request_24">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews?seatId=26693&amp;page=0&amp;size=1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews?seatId=26840&amp;page=0&amp;size=1 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -3468,11 +3502,11 @@ Host: localhost:8080</code></pre>
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 154
+Content-Length: 152
 
 {
   "reviews" : [ {
-    "reviewId" : 4108,
+    "reviewId" : 76,
     "title" : "테스트 제목",
     "score" : 5,
     "viewCount" : 0,
@@ -3604,7 +3638,7 @@ Content-Length: 217
   "url" : "/api/v1/reviews",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-07 02:37:52",
+  "createdAt" : "2023-08-21 22:23:54",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3669,7 +3703,7 @@ Content-Length: 217
             <h5 id="_request_25"><a class="link" href="#_request_25">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews/4122 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews/90 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -3723,7 +3757,7 @@ Host: localhost:8080</code></pre>
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: USER_KEY=63e15188-0b08-4a95-8c36-0dd72ab34f5b; Path=/; Max-Age=86400; Expires=Mon, 07 Aug 2023 17:37:54 GMT; Secure; HttpOnly
+Set-Cookie: USER_KEY=cf8dccba-be24-4109-810f-3aec14d34c41; Path=/; Max-Age=86400; Expires=Tue, 22 Aug 2023 13:23:56 GMT; Secure; HttpOnly
 Content-Type: application/json
 Content-Length: 131
 
@@ -3842,7 +3876,7 @@ Host: localhost:8080</code></pre>
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 404 Not Found
-Set-Cookie: USER_KEY=911885d5-2a38-4a26-bc72-fa65a2f06e70; Path=/; Max-Age=86400; Expires=Mon, 07 Aug 2023 17:37:50 GMT; Secure; HttpOnly
+Set-Cookie: USER_KEY=c6211764-f1e8-459b-bde4-8cc6a61f7a7e; Path=/; Max-Age=86400; Expires=Tue, 22 Aug 2023 13:23:52 GMT; Secure; HttpOnly
 Content-Type: application/json
 Content-Length: 220
 
@@ -3851,7 +3885,7 @@ Content-Length: 220
   "url" : "/api/v1/reviews/-1",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-07 02:37:50",
+  "createdAt" : "2023-08-21 22:23:52",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3923,11 +3957,11 @@ Content-Length: 220
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/reviewvotes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 51
+Content-Length: 49
 Host: localhost:8080
 
 {
-  "reviewId" : 4087,
+  "reviewId" : 51,
   "voteChoice" : "LIKE"
 }</code></pre>
               </div>
@@ -3988,7 +4022,7 @@ Host: localhost:8080
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Location: /api/v1/reviewvotes/4087</code></pre>
+Location: /api/v1/reviewvotes/14</code></pre>
               </div>
             </div>
           </div>
@@ -4001,11 +4035,11 @@ Location: /api/v1/reviewvotes/4087</code></pre>
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/reviewvotes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 51
+Content-Length: 49
 Host: localhost:8080
 
 {
-  "reviewId" : 4099,
+  "reviewId" : 67,
   "voteChoice" : "LIKE"
 }</code></pre>
               </div>
@@ -4074,7 +4108,7 @@ Content-Length: 227
   "url" : "/api/v1/reviewvotes",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-07 02:37:34",
+  "createdAt" : "2023-08-21 22:23:31",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4138,11 +4172,11 @@ Content-Length: 227
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/reviewvotes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 51
+Content-Length: 49
 Host: localhost:8080
 
 {
-  "reviewId" : 4093,
+  "reviewId" : 61,
   "voteChoice" : "LIKE"
 }</code></pre>
               </div>
@@ -4211,7 +4245,7 @@ Content-Length: 221
   "url" : "/api/v1/reviewvotes",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-07 02:37:32",
+  "createdAt" : "2023-08-21 22:23:29",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4348,7 +4382,7 @@ Content-Length: 221
   "url" : "/api/v1/reviewvotes",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-07 02:37:33",
+  "createdAt" : "2023-08-21 22:23:31",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4412,11 +4446,11 @@ Content-Length: 221
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/reviewvotes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 51
+Content-Length: 49
 Host: localhost:8080
 
 {
-  "reviewId" : 4095,
+  "reviewId" : 63,
   "voteChoice" : "LIKE"
 }</code></pre>
               </div>
@@ -4485,7 +4519,7 @@ Content-Length: 217
   "url" : "/api/v1/reviewvotes",
   "exceptionName" : "DuplicatedException",
   "message" : "이미 평가한 후기입니다.",
-  "createdAt" : "2023-08-07 02:37:33",
+  "createdAt" : "2023-08-21 22:23:30",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4550,7 +4584,7 @@ Content-Length: 217
             <h5 id="_request_32"><a class="link" href="#_request_32">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviewvotes/108 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviewvotes/12 HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
@@ -4588,10 +4622,13 @@ Host: localhost:8080</code></pre>
         </div>
         <div class="sect3">
           <h4 id="_실패_후기_투표_id_없는_경우"><a class="link" href="#_실패_후기_투표_id_없는_경우">실패 - 후기 투표 id 없는 경우</a></h4>
-          <div class="listingblock">
-            <div class="content">
+          <div class="sect4">
+            <h5 id="_request_33"><a class="link" href="#_request_33">Request</a></h5>
+            <div class="listingblock">
+              <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviewvotes/0 HTTP/1.1
 Host: localhost:8080</code></pre>
+              </div>
             </div>
           </div>
           <div class="sect4">
@@ -4629,7 +4666,7 @@ Content-Length: 223
   "url" : "/api/v1/reviewvotes/0",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-07 02:37:30",
+  "createdAt" : "2023-08-21 22:23:27",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4687,10 +4724,13 @@ Content-Length: 223
         </div>
         <div class="sect3">
           <h4 id="_실패_후기_투표자가_아닌_경우"><a class="link" href="#_실패_후기_투표자가_아닌_경우">실패 - 후기 투표자가 아닌 경우</a></h4>
-          <div class="listingblock">
-            <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviewvotes/112 HTTP/1.1
+          <div class="sect4">
+            <h5 id="_request_34"><a class="link" href="#_request_34">Request</a></h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviewvotes/18 HTTP/1.1
 Host: localhost:8080</code></pre>
+              </div>
             </div>
           </div>
           <div class="sect4">
@@ -4721,14 +4761,14 @@ Host: localhost:8080</code></pre>
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
 Content-Type: application/json
-Content-Length: 231
+Content-Length: 230
 
 {
   "status" : 401,
-  "url" : "/api/v1/reviewvotes/112",
+  "url" : "/api/v1/reviewvotes/18",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-07 02:37:31",
+  "createdAt" : "2023-08-21 22:23:28",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4785,12 +4825,205 @@ Content-Length: 231
           </div>
         </div>
       </div>
+      <div class="sect2">
+        <h3 id="_6_3_후기_투표_조회"><a class="link" href="#_6_3_후기_투표_조회">6-3. 후기 투표 조회</a></h3>
+        <div class="sect3">
+          <h4 id="_성공_17"><a class="link" href="#_성공_17">성공</a></h4>
+          <div class="sect4">
+            <h5 id="_request_35"><a class="link" href="#_request_35">Request</a></h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviewvotes?reviewId=55 HTTP/1.1
+Host: localhost:8080</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_request_parameters_17"><a class="link" href="#_request_parameters_17">Request Parameters</a></h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 50%;">
+                <col style="width: 50%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Parameter</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>reviewId</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">연관된 후기 id</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_response_38"><a class="link" href="#_response_38">Response</a></h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 97
+
+{
+  "likeCount" : 0,
+  "dislikeCount" : 0,
+  "clickLike" : false,
+  "clickDislike" : false
+}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_response_fields_29"><a class="link" href="#_response_fields_29">Response Fields</a></h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>likeCount</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 수</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>dislikeCount</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">싫어요 수</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>clickLike</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 등록 여부</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>clickDislike</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">싫어요 등록 여부</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="sect3">
+          <h4 id="_실패_연관된_후기가_없는_경우"><a class="link" href="#_실패_연관된_후기가_없는_경우">실패 - 연관된 후기가 없는 경우</a></h4>
+          <div class="sect4">
+            <h5 id="_request_36"><a class="link" href="#_request_36">Request</a></h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviewvotes?reviewId=0 HTTP/1.1
+Host: localhost:8080</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_request_parameters_18"><a class="link" href="#_request_parameters_18">Request Parameters</a></h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 50%;">
+                <col style="width: 50%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Parameter</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>reviewId</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">연관된 후기 id</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_response_39"><a class="link" href="#_response_39">Response</a></h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 404 Not Found
+Content-Type: application/json
+Content-Length: 221
+
+{
+  "status" : 404,
+  "url" : "/api/v1/reviewvotes",
+  "exceptionName" : "NotFoundException",
+  "message" : "존재하지 않는 데이터입니다.",
+  "createdAt" : "2023-08-21 22:23:25",
+  "fieldErrors" : null
+}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_response_fields_30"><a class="link" href="#_response_fields_30">Response Fields</a></h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 상태 코드</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>url</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">요청한 url</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>exceptionName</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">발생한 예외 이름</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">예외 메세지</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdAt</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">예외 발생 시간</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>fieldErrors</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">필드 에러 목록</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
 <div id="footer">
   <div id="footer-text">
-    Last updated 2023-08-07 02:37:06 +0900
+    Last updated 2023-08-21 22:25:30 +0900
   </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/goodseats/seatviewreviews/domain/vote/controller/ReviewVoteControllerTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/vote/controller/ReviewVoteControllerTest.java
@@ -359,7 +359,57 @@ class ReviewVoteControllerTest {
 									fieldWithPath("createdAt").type(JsonFieldType.STRING).description("예외 발생 시간"),
 									fieldWithPath("fieldErrors").type(JsonFieldType.NULL).description("필드 에러 목록")
 							)));
-
 		}
+	}
+
+	@Test
+	@DisplayName("Success - 후기 투표 정보 조회에 성공하고 200 응답한다")
+	void getVotesSuccessWhenLogin() throws Exception {
+		// given
+		MockHttpSession session = TestUtils.getLoginSession(voter, USER);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/reviewvotes")
+						.param("reviewId", publishedReview.getId().toString())
+						.session(session))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andDo(document("후기 투표 조회 성공",
+						preprocessRequest(prettyPrint()),
+						preprocessResponse(prettyPrint()),
+						requestParameters(parameterWithName("reviewId").description("연관된 후기 id")),
+						responseFields(
+								fieldWithPath("likeCount").type(JsonFieldType.NUMBER).description("좋아요 수"),
+								fieldWithPath("dislikeCount").type(JsonFieldType.NUMBER).description("싫어요 수"),
+								fieldWithPath("clickLike").type(JsonFieldType.BOOLEAN).description("좋아요 등록 여부"),
+								fieldWithPath("clickDislike").type(JsonFieldType.BOOLEAN).description("싫어요 등록 여부")
+						)));
+	}
+
+	@Test
+	@DisplayName("Fail - 연관된 후기가 없으면 후기 투표 조회에 실패하고 404 응답한다")
+	void getVotesFailByNotFoundReview() throws Exception {
+		// given
+		MockHttpSession session = TestUtils.getLoginSession(voter, USER);
+		Long wrongReviewId = 0L;
+
+		// when & then
+		mockMvc.perform(get("/api/v1/reviewvotes")
+						.param("reviewId", wrongReviewId.toString())
+						.session(session))
+				.andExpect(status().isNotFound())
+				.andDo(print())
+				.andDo(document("후기 투표 조회 실패 - 연관된 후기가 없는 경우",
+						preprocessRequest(prettyPrint()),
+						preprocessResponse(prettyPrint()),
+						requestParameters(parameterWithName("reviewId").description("연관된 후기 id")),
+						responseFields(
+								fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+								fieldWithPath("url").type(JsonFieldType.STRING).description("요청한 url"),
+								fieldWithPath("exceptionName").type(JsonFieldType.STRING).description("발생한 예외 이름"),
+								fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메세지"),
+								fieldWithPath("createdAt").type(JsonFieldType.STRING).description("예외 발생 시간"),
+								fieldWithPath("fieldErrors").type(JsonFieldType.NULL).description("필드 에러 목록")
+						)));
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #171 

### 내용
- 투표 조회 시 투표 수(좋아요 수, 싫어요 수), 투표 등록 여부를 반환함
- 후기 테이블에 좋아요 수, 싫어요 수 컬럼을 추가하여 조회 성능 개선
  - 기존의 투표 테이블에서 count 쿼리로 투표 수를 조회하는 방식은 대용량 데이터 환경에서 조회 시 오랜 시간이 걸림
  - 실제로 400만 데이터 상에서 커버링 인덱스를 적용하였음에도 0.5초 가량이 걸렸음