### PR TITLE
Fix: 후기 테이블의 투표 수 컬럼 추가로 인한 동시성 제어 로직 추가

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/common/constant/RedisConstant.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/constant/RedisConstant.java
@@ -11,7 +11,8 @@ public class RedisConstant {
 	public static final String REVIEW_AND_VIEW_COUNT_LOGS_NAME = "reviewViewCountLogs";
 	public static final String DELIMITER = "_";
 	public static final String SEPARATOR = ", ";
-	public static final String LOCK_NAME = "viewCountLock";
+	public static final String VIEW_COUNT_LOCK = "viewCountLock";
+	public static final String REVIEW_VOTE_LOCK = "reviewVoteLock";
 	public static final int LOCK_WAIT_TIME = 10;
 	public static final int LEASE_TIME = 5;
 	public static final String VIEWED_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/service/ReviewRedisFacade.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/service/ReviewRedisFacade.java
@@ -56,7 +56,7 @@ public class ReviewRedisFacade {
 	}
 
 	private void controlViewCountConcurrency(String userKey, Long reviewId) {
-		RLock viewCountLock = redissonClient.getLock(LOCK_NAME);
+		RLock viewCountLock = redissonClient.getLock(VIEW_COUNT_LOCK);
 
 		try {
 			tryLock(viewCountLock);

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/controller/ReviewVoteController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/controller/ReviewVoteController.java
@@ -26,6 +26,7 @@ import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
 import com.goodseats.seatviewreviews.domain.vote.model.dto.request.ReviewVoteCreateRequest;
 import com.goodseats.seatviewreviews.domain.vote.model.dto.request.ReviewVotesGetRequest;
 import com.goodseats.seatviewreviews.domain.vote.model.dto.response.ReviewVotesResponse;
+import com.goodseats.seatviewreviews.domain.vote.service.ReviewVoteRedisFacade;
 import com.goodseats.seatviewreviews.domain.vote.service.ReviewVoteService;
 
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 public class ReviewVoteController {
 
 	private final ReviewVoteService reviewVoteService;
+	private final ReviewVoteRedisFacade reviewVoteRedisFacade;
 
 	@Authority(authorities = {USER, ADMIN})
 	@PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
@@ -44,7 +46,7 @@ public class ReviewVoteController {
 			@SessionAttribute(value = LOGIN_MEMBER_INFO) AuthenticationDTO authenticationDTO,
 			HttpServletRequest request
 	) {
-		Long voteId = reviewVoteService.createVote(reviewVoteCreateRequest, authenticationDTO.memberId());
+		Long voteId = reviewVoteRedisFacade.createVote(reviewVoteCreateRequest, authenticationDTO.memberId());
 		return ResponseEntity.created(URI.create(request.getRequestURI() + "/" + voteId)).build();
 	}
 
@@ -54,7 +56,7 @@ public class ReviewVoteController {
 			@PathVariable Long reviewVoteId,
 			@SessionAttribute(value = LOGIN_MEMBER_INFO) AuthenticationDTO authenticationDTO
 	) {
-		reviewVoteService.deleteVote(reviewVoteId, authenticationDTO.memberId());
+		reviewVoteRedisFacade.deleteVote(reviewVoteId, authenticationDTO.memberId());
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/repository/ReviewVoteRepository.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/repository/ReviewVoteRepository.java
@@ -3,14 +3,20 @@ package com.goodseats.seatviewreviews.domain.vote.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
 import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
 import com.goodseats.seatviewreviews.domain.vote.model.entity.ReviewVote;
+import com.goodseats.seatviewreviews.domain.vote.model.vo.VoteChoice;
 
 public interface ReviewVoteRepository extends JpaRepository<ReviewVote, Long> {
 
 	boolean existsByMemberAndReview(Member member, Review review);
 
 	Optional<ReviewVote> findReviewVoteByMemberAndReview(Member member, Review review);
+
+	@Query("SELECT COUNT(*) FROM ReviewVote rv WHERE rv.review.id = :reviewId AND rv.voteChoice = :voteChoice")
+	int getVoteCount(@Param("reviewId") Long reviewId, @Param("voteChoice") VoteChoice voteChoice);
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/service/ReviewVoteRedisFacade.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/service/ReviewVoteRedisFacade.java
@@ -1,0 +1,62 @@
+package com.goodseats.seatviewreviews.domain.vote.service;
+
+import static com.goodseats.seatviewreviews.common.constant.RedisConstant.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import com.goodseats.seatviewreviews.domain.vote.model.dto.request.ReviewVoteCreateRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewVoteRedisFacade {
+
+	private final RedissonClient redissonClient;
+	private final ReviewVoteService reviewVoteService;
+
+	public Long createVote(ReviewVoteCreateRequest reviewVoteCreateRequest, Long memberId) {
+		RLock reviewVoteLock = redissonClient.getLock(REVIEW_VOTE_LOCK);
+		Long reviewVoteId;
+
+		try {
+			tryLock(reviewVoteLock);
+			reviewVoteId = reviewVoteService.createVote(reviewVoteCreateRequest, memberId);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		} finally {
+			if (reviewVoteLock.isHeldByCurrentThread()) {
+				reviewVoteLock.unlock();
+			}
+		}
+
+		return reviewVoteId;
+	}
+
+	public void deleteVote(Long reviewVoteId, Long memberId) {
+		RLock reviewVoteLock = redissonClient.getLock(REVIEW_VOTE_LOCK);
+
+		try {
+			tryLock(reviewVoteLock);
+			reviewVoteService.deleteVote(reviewVoteId, memberId);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		} finally {
+			if (reviewVoteLock.isHeldByCurrentThread()) {
+				reviewVoteLock.unlock();
+			}
+		}
+	}
+
+	private void tryLock(RLock reviewVoteLock) throws InterruptedException {
+		boolean available = reviewVoteLock.tryLock(LOCK_WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS);
+
+		if (!available) {
+			throw new InterruptedException();
+		}
+	}
+}

--- a/src/main/resources/static/docs/rest-docs.html
+++ b/src/main/resources/static/docs/rest-docs.html
@@ -708,11 +708,11 @@ Content-Length: 2257
     "name" : "잠실 야구장",
     "homeTeam" : "DOOSAN_LG"
   }, {
-    "stadiumId" : 2938,
+    "stadiumId" : 3140,
     "name" : "잠실 야구장",
     "homeTeam" : "DOOSAN_LG"
   }, {
-    "stadiumId" : 2939,
+    "stadiumId" : 3141,
     "name" : "한화생명 이글스 파크",
     "homeTeam" : "HANWHA"
   } ]
@@ -769,7 +769,7 @@ Content-Length: 2257
             <h5 id="_request_2"><a class="link" href="#_request_2">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/stadiums/2937 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/stadiums/3139 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -931,7 +931,7 @@ Content-Length: 221
   "url" : "/api/v1/stadiums/-1",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-21 22:23:40",
+  "createdAt" : "2023-08-25 00:23:01",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -1001,7 +1001,7 @@ Content-Length: 221
             <h5 id="_request_4"><a class="link" href="#_request_4">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/sections?stadiumId=2952 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/sections?stadiumId=3154 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -1059,10 +1059,10 @@ Content-Length: 147
 
 {
   "seatSections" : [ {
-    "sectionId" : 2722,
+    "sectionId" : 2908,
     "sectionName" : "110"
   }, {
-    "sectionId" : 2723,
+    "sectionId" : 2909,
     "sectionName" : "111"
   } ]
 }</code></pre>
@@ -1113,7 +1113,7 @@ Content-Length: 147
             <h5 id="_request_5"><a class="link" href="#_request_5">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/seats?sectionId=2724 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/seats?sectionId=2910 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -1293,7 +1293,7 @@ loginEmail=goodseat%40google.com&amp;password=password&amp;nickname=Jerome</code
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Location: /api/v1/members/1016640</code></pre>
+Location: /api/v1/members/6953</code></pre>
               </div>
             </div>
           </div>
@@ -1375,7 +1375,7 @@ Content-Length: 209
   "url" : "/api/v1/members",
   "exceptionName" : "DuplicatedException",
   "message" : "중복된 아이디입니다.",
-  "createdAt" : "2023-08-21 22:23:59",
+  "createdAt" : "2023-08-25 00:23:30",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -1508,7 +1508,7 @@ Content-Length: 209
   "url" : "/api/v1/members",
   "exceptionName" : "DuplicatedException",
   "message" : "중복된 아이디입니다.",
-  "createdAt" : "2023-08-21 22:23:59",
+  "createdAt" : "2023-08-25 00:23:30",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -1709,7 +1709,7 @@ Content-Length: 236
   "url" : "/api/v1/members/login",
   "exceptionName" : "AuthenticationException",
   "message" : "아이디 혹은 비밀번호가 틀립니다.",
-  "createdAt" : "2023-08-21 22:23:58",
+  "createdAt" : "2023-08-25 00:23:29",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -1838,7 +1838,7 @@ Content-Length: 236
   "url" : "/api/v1/members/login",
   "exceptionName" : "AuthenticationException",
   "message" : "아이디 혹은 비밀번호가 틀립니다.",
-  "createdAt" : "2023-08-21 22:23:59",
+  "createdAt" : "2023-08-25 00:23:30",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -1941,7 +1941,7 @@ Content-Length: 230
   "url" : "/api/v1/members/logout",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-21 22:23:58",
+  "createdAt" : "2023-08-25 00:23:28",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2113,8 +2113,8 @@ Content-Type: application/json
 Content-Length: 149
 
 {
-  "imageId" : 815,
-  "imageUrl" : "https://seat-view-reviews.s3.ap-northeast-2.amazonaws.com/reviews/eba19dab-0c17-4af5-8e6f-56e55e269424.png"
+  "imageId" : 855,
+  "imageUrl" : "https://seat-view-reviews.s3.ap-northeast-2.amazonaws.com/reviews/b5facf8a-1acd-4a4f-98a0-0a0115f48d94.png"
 }</code></pre>
               </div>
             </div>
@@ -2261,7 +2261,7 @@ Content-Length: 222
   "url" : "/api/v1/images",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-21 22:24:00",
+  "createdAt" : "2023-08-25 00:23:33",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2429,7 +2429,7 @@ Content-Length: 230
   "url" : "/api/v1/images",
   "exceptionName" : "IllegalArgumentException",
   "message" : "잘못된 이미지 업로드 요청입니다.",
-  "createdAt" : "2023-08-21 22:24:00",
+  "createdAt" : "2023-08-25 00:23:33",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2574,7 +2574,7 @@ Host: localhost:8080
             <h5 id="_request_18"><a class="link" href="#_request_18">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/images/816 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/images/856 HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
@@ -2656,7 +2656,7 @@ Content-Length: 218
   "url" : "/api/v1/images/1",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-21 22:24:00",
+  "createdAt" : "2023-08-25 00:23:33",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2718,7 +2718,7 @@ Content-Length: 218
             <h5 id="_request_20"><a class="link" href="#_request_20">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/images/817 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/images/857 HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
@@ -2755,10 +2755,10 @@ Content-Length: 219
 
 {
   "status" : 409,
-  "url" : "/api/v1/images/817",
+  "url" : "/api/v1/images/857",
   "exceptionName" : "DuplicatedException",
   "message" : "이미 삭제된 데이터입니다.",
-  "createdAt" : "2023-08-21 22:24:00",
+  "createdAt" : "2023-08-25 00:23:33",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2835,7 +2835,7 @@ Content-Length: 24
 Host: localhost:8080
 
 {
-  "seatId" : 26837
+  "seatId" : 27015
 }</code></pre>
               </div>
             </div>
@@ -2894,7 +2894,7 @@ Host: localhost:8080
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Location: /api/v1/reviews/70</code></pre>
+Location: /api/v1/reviews/418</code></pre>
               </div>
             </div>
           </div>
@@ -2979,7 +2979,7 @@ Content-Length: 217
   "url" : "/api/v1/reviews",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-21 22:23:55",
+  "createdAt" : "2023-08-25 00:23:16",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3044,7 +3044,7 @@ Content-Length: 217
             <h5 id="_request_23"><a class="link" href="#_request_23">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/reviews/79 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/reviews/427 HTTP/1.1
 Content-Type: application/x-www-form-urlencoded;charset=UTF-8
 Host: localhost:8080</code></pre>
               </div>
@@ -3225,7 +3225,7 @@ Content-Length: 219
   "url" : "/api/v1/reviews/1",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-21 22:23:57",
+  "createdAt" : "2023-08-25 00:23:26",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3368,14 +3368,14 @@ Host: localhost:8080</code></pre>
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
 Content-Type: application/json
-Content-Length: 226
+Content-Length: 227
 
 {
   "status" : 401,
-  "url" : "/api/v1/reviews/91",
+  "url" : "/api/v1/reviews/439",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-21 22:23:57",
+  "createdAt" : "2023-08-25 00:23:20",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3440,7 +3440,7 @@ Content-Length: 226
             <h5 id="_request_24"><a class="link" href="#_request_24">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews?seatId=26840&amp;page=0&amp;size=1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews?seatId=27018&amp;page=0&amp;size=1 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -3502,11 +3502,11 @@ Host: localhost:8080</code></pre>
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 152
+Content-Length: 153
 
 {
   "reviews" : [ {
-    "reviewId" : 76,
+    "reviewId" : 424,
     "title" : "테스트 제목",
     "score" : 5,
     "viewCount" : 0,
@@ -3638,7 +3638,7 @@ Content-Length: 217
   "url" : "/api/v1/reviews",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-21 22:23:54",
+  "createdAt" : "2023-08-25 00:23:16",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3703,7 +3703,7 @@ Content-Length: 217
             <h5 id="_request_25"><a class="link" href="#_request_25">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews/90 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews/438 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -3757,7 +3757,7 @@ Host: localhost:8080</code></pre>
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: USER_KEY=cf8dccba-be24-4109-810f-3aec14d34c41; Path=/; Max-Age=86400; Expires=Tue, 22 Aug 2023 13:23:56 GMT; Secure; HttpOnly
+Set-Cookie: USER_KEY=9327e5ba-8d75-42c4-80a6-9786e18de40f; Path=/; Max-Age=86400; Expires=Fri, 25 Aug 2023 15:23:20 GMT; Secure; HttpOnly
 Content-Type: application/json
 Content-Length: 131
 
@@ -3876,7 +3876,7 @@ Host: localhost:8080</code></pre>
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 404 Not Found
-Set-Cookie: USER_KEY=c6211764-f1e8-459b-bde4-8cc6a61f7a7e; Path=/; Max-Age=86400; Expires=Tue, 22 Aug 2023 13:23:52 GMT; Secure; HttpOnly
+Set-Cookie: USER_KEY=32084a90-6419-4373-9eeb-c2a994f2a2c3; Path=/; Max-Age=86400; Expires=Fri, 25 Aug 2023 15:23:13 GMT; Secure; HttpOnly
 Content-Type: application/json
 Content-Length: 220
 
@@ -3885,7 +3885,7 @@ Content-Length: 220
   "url" : "/api/v1/reviews/-1",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-21 22:23:52",
+  "createdAt" : "2023-08-25 00:23:13",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3957,11 +3957,11 @@ Content-Length: 220
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/reviewvotes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 49
+Content-Length: 50
 Host: localhost:8080
 
 {
-  "reviewId" : 51,
+  "reviewId" : 399,
   "voteChoice" : "LIKE"
 }</code></pre>
               </div>
@@ -4022,7 +4022,7 @@ Host: localhost:8080
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Location: /api/v1/reviewvotes/14</code></pre>
+Location: /api/v1/reviewvotes/659</code></pre>
               </div>
             </div>
           </div>
@@ -4035,11 +4035,11 @@ Location: /api/v1/reviewvotes/14</code></pre>
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/reviewvotes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 49
+Content-Length: 50
 Host: localhost:8080
 
 {
-  "reviewId" : 67,
+  "reviewId" : 415,
   "voteChoice" : "LIKE"
 }</code></pre>
               </div>
@@ -4108,7 +4108,7 @@ Content-Length: 227
   "url" : "/api/v1/reviewvotes",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-21 22:23:31",
+  "createdAt" : "2023-08-25 00:22:51",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4172,11 +4172,11 @@ Content-Length: 227
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/reviewvotes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 49
+Content-Length: 50
 Host: localhost:8080
 
 {
-  "reviewId" : 61,
+  "reviewId" : 409,
   "voteChoice" : "LIKE"
 }</code></pre>
               </div>
@@ -4245,7 +4245,7 @@ Content-Length: 221
   "url" : "/api/v1/reviewvotes",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-21 22:23:29",
+  "createdAt" : "2023-08-25 00:22:47",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4382,7 +4382,7 @@ Content-Length: 221
   "url" : "/api/v1/reviewvotes",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-21 22:23:31",
+  "createdAt" : "2023-08-25 00:22:49",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4446,11 +4446,11 @@ Content-Length: 221
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/reviewvotes HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 49
+Content-Length: 50
 Host: localhost:8080
 
 {
-  "reviewId" : 63,
+  "reviewId" : 411,
   "voteChoice" : "LIKE"
 }</code></pre>
               </div>
@@ -4519,7 +4519,7 @@ Content-Length: 217
   "url" : "/api/v1/reviewvotes",
   "exceptionName" : "DuplicatedException",
   "message" : "이미 평가한 후기입니다.",
-  "createdAt" : "2023-08-21 22:23:30",
+  "createdAt" : "2023-08-25 00:22:48",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4584,7 +4584,7 @@ Content-Length: 217
             <h5 id="_request_32"><a class="link" href="#_request_32">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviewvotes/12 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviewvotes/556 HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
@@ -4666,7 +4666,7 @@ Content-Length: 223
   "url" : "/api/v1/reviewvotes/0",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-21 22:23:27",
+  "createdAt" : "2023-08-25 00:22:45",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4728,7 +4728,7 @@ Content-Length: 223
             <h5 id="_request_34"><a class="link" href="#_request_34">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviewvotes/18 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviewvotes/663 HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
@@ -4761,14 +4761,14 @@ Host: localhost:8080</code></pre>
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
 Content-Type: application/json
-Content-Length: 230
+Content-Length: 231
 
 {
   "status" : 401,
-  "url" : "/api/v1/reviewvotes/18",
+  "url" : "/api/v1/reviewvotes/663",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-21 22:23:28",
+  "createdAt" : "2023-08-25 00:22:46",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4833,7 +4833,7 @@ Content-Length: 230
             <h5 id="_request_35"><a class="link" href="#_request_35">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviewvotes?reviewId=55 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviewvotes?reviewId=403 HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
@@ -4961,7 +4961,7 @@ Content-Length: 221
   "url" : "/api/v1/reviewvotes",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-21 22:23:25",
+  "createdAt" : "2023-08-25 00:22:42",
   "fieldErrors" : null
 }</code></pre>
               </div>

--- a/src/test/java/com/goodseats/seatviewreviews/domain/vote/service/ReviewVoteServiceTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/vote/service/ReviewVoteServiceTest.java
@@ -93,7 +93,9 @@ class ReviewVoteServiceTest {
 		when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
 		when(reviewRepository.findById(reviewVoteCreateRequest.reviewId())).thenReturn(Optional.of(publishedReview));
 		when(reviewVoteRepository.existsByMemberAndReview(member, publishedReview)).thenReturn(false);
-		when(reviewVoteRepository.save(any(ReviewVote.class))).thenReturn(any(ReviewVote.class));
+		when(reviewVoteRepository.save(any(ReviewVote.class))).thenReturn(reviewVote);
+		when(reviewVoteRepository.getVoteCount(reviewVoteCreateRequest.reviewId(), reviewVoteCreateRequest.voteChoice()))
+				.thenReturn(anyInt());
 
 		// when
 		reviewVoteService.createVote(reviewVoteCreateRequest, memberId);
@@ -103,6 +105,7 @@ class ReviewVoteServiceTest {
 		verify(reviewRepository).findById(reviewVoteCreateRequest.reviewId());
 		verify(reviewVoteRepository).existsByMemberAndReview(member, publishedReview);
 		verify(reviewVoteRepository).save(any(ReviewVote.class));
+		verify(reviewVoteRepository).getVoteCount(reviewVoteCreateRequest.reviewId(), reviewVoteCreateRequest.voteChoice());
 	}
 
 	@Nested
@@ -174,6 +177,8 @@ class ReviewVoteServiceTest {
 		// given
 		when(reviewVoteRepository.findById(reviewVote.getId())).thenReturn(Optional.of(reviewVote));
 		doNothing().when(reviewVoteRepository).delete(reviewVote);
+		when(reviewVoteRepository.getVoteCount(reviewVote.getReview().getId(), reviewVote.getVoteChoice()))
+				.thenReturn(anyInt());
 
 		// when
 		reviewVoteService.deleteVote(reviewVote.getId(), member.getId());
@@ -181,6 +186,7 @@ class ReviewVoteServiceTest {
 		// then
 		verify(reviewVoteRepository).findById(reviewVote.getId());
 		verify(reviewVoteRepository).delete(reviewVote);
+		verify(reviewVoteRepository).getVoteCount(reviewVote.getReview().getId(), reviewVote.getVoteChoice());
 	}
 
 	@Nested


### PR DESCRIPTION
### 관련 이슈
- close #172 

### 내용
- 락을 걸지 여부
    - 투표 수가 실시간으로 정합성이 맞아야하는 것은 아님. 일정 주기로 투표 테이블에 있는 수를 count 해서 후기의 투표 수 컬럼에 반영해줘도 됨. 다만 후기의 수가 많아질수록 부담이 커지므로 락을 거는 방식으로 해결하기로 함.
- 어떤 식으로 락을 걸 것인가?
    - synchronized, 비관적락, 낙관적락, 분산락 정도가 있음.
        - 비관적락
            - 투표 테이블에 쓰기 락이 걸림. 투표 생성 중에는 다른 트랜잭션에서 투표 테이블의 조회도 불가능하게 됨. 투표는 생성보다도 조회가 잦음. 성능적으로 이슈 있음.
        - 낙관적락
            - 투표 생성은 충돌이 자주 일어나지 않을 것이라 판단됨. 대규모 커뮤니티 실시간 인기글을 보아도 투표 수가 많아야 300개 정도임. 프론트 단에서 투표 생성 시 모달 창 단계를 추가한다면 더더욱 충돌이 줄어들 것임.
        - 결론
            - 현재 서버는 싱글 서버, 싱글 DB 라서 낙관적락으로도 충분함. 다만, 분산 서버, 분산 DB 환경임을 가정한다면 버전을 동기화해주는 추가적인 리소스가 필요함. synchronized 도 같은 이유로 배제하고 Redis 를 활용한 분산락을 선택함.