### PR TITLE
Fix: 회원만 조회 수 증가 가능하도록 수정

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/controller/ReviewController.java
@@ -1,19 +1,15 @@
 package com.goodseats.seatviewreviews.domain.review.controller;
 
-import static com.goodseats.seatviewreviews.common.constant.CookieConstant.*;
 import static com.goodseats.seatviewreviews.domain.member.model.vo.MemberAuthority.*;
 
 import java.net.URI;
 
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -27,7 +23,6 @@ import org.springframework.web.bind.annotation.SessionAttribute;
 
 import com.goodseats.seatviewreviews.common.security.Authority;
 import com.goodseats.seatviewreviews.common.security.SessionConstant;
-import com.goodseats.seatviewreviews.common.util.CookieUtils;
 import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
 import com.goodseats.seatviewreviews.domain.review.model.dto.request.ReviewPublishRequest;
 import com.goodseats.seatviewreviews.domain.review.model.dto.request.TempReviewCreateRequest;
@@ -71,11 +66,9 @@ public class ReviewController {
 	@GetMapping(value = "/{reviewId}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<ReviewDetailResponse> getReview(
 			@PathVariable Long reviewId,
-			@CookieValue(value = USER_KEY, required = false) Cookie userKey,
-			HttpServletResponse response
+			@SessionAttribute(value = SessionConstant.LOGIN_MEMBER_INFO, required = false) AuthenticationDTO authenticationDTO
 	) {
-		userKey = CookieUtils.setUserKey(userKey, response);
-		ReviewDetailResponse reviewDetailResponse = reviewRedisFacade.getReview(userKey.getValue(), reviewId);
+		ReviewDetailResponse reviewDetailResponse = reviewRedisFacade.getReview(authenticationDTO, reviewId);
 		return ResponseEntity.ok(reviewDetailResponse);
 	}
 

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/service/ReviewRedisFacade.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/service/ReviewRedisFacade.java
@@ -5,6 +5,7 @@ import static com.goodseats.seatviewreviews.common.constant.RedisConstant.*;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.redisson.api.RLock;
@@ -13,6 +14,7 @@ import org.redisson.api.RSet;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
 
+import com.goodseats.seatviewreviews.domain.member.model.dto.AuthenticationDTO;
 import com.goodseats.seatviewreviews.domain.review.model.dto.response.ReviewDetailResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -24,9 +26,12 @@ public class ReviewRedisFacade {
 	private final RedissonClient redissonClient;
 	private final ReviewService reviewService;
 
-	public ReviewDetailResponse getReview(String userKey, Long reviewId) {
-		if (hasNotViewedReview(userKey, reviewId)) {
-			controlViewCountConcurrency(userKey, reviewId);
+	public ReviewDetailResponse getReview(AuthenticationDTO authenticationDTO, Long reviewId) {
+		if (Objects.isNull(authenticationDTO)) {
+			return reviewService.getReview(reviewId);
+		}
+		if (hasNotViewedReview(authenticationDTO.memberId(), reviewId)) {
+			controlViewCountConcurrency(authenticationDTO.memberId(), reviewId);
 		}
 
 		return reviewService.getReview(reviewId);
@@ -55,13 +60,13 @@ public class ReviewRedisFacade {
 		}
 	}
 
-	private void controlViewCountConcurrency(String userKey, Long reviewId) {
+	private void controlViewCountConcurrency(Long memberId, Long reviewId) {
 		RLock viewCountLock = redissonClient.getLock(VIEW_COUNT_LOCK);
 
 		try {
 			tryLock(viewCountLock);
 
-			String userViewedReviewLog = generateUserViewedReviewLog(userKey, reviewId);
+			String userViewedReviewLog = generateUserViewedReviewLog(memberId, reviewId);
 			ReviewDetailResponse reviewDetailResponse = reviewService.getReview(reviewId);
 			saveUserViewedReviewLog(userViewedReviewLog);
 			increaseViewCount(reviewId, reviewDetailResponse.viewCount());
@@ -82,12 +87,12 @@ public class ReviewRedisFacade {
 		}
 	}
 
-	private String generateUserViewedReviewLog(String userKey, Long reviewId) {
-		return "user" + "_" + userKey + ", " + "reviewId" + "_" + reviewId;
+	private String generateUserViewedReviewLog(Long memberId, Long reviewId) {
+		return "memberId" + "_" + memberId + ", " + "reviewId" + "_" + reviewId;
 	}
 
-	private boolean hasNotViewedReview(String userKey, Long reviewId) {
-		String userViewedReviewLog = generateUserViewedReviewLog(userKey, reviewId);
+	private boolean hasNotViewedReview(Long memberId, Long reviewId) {
+		String userViewedReviewLog = generateUserViewedReviewLog(memberId, reviewId);
 		return !redissonClient.getSet(USER_VIEWED_REVIEW_LOGS_NAME).contains(userViewedReviewLog);
 	}
 

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/service/ReviewRedisFacade.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/service/ReviewRedisFacade.java
@@ -30,7 +30,7 @@ public class ReviewRedisFacade {
 		if (Objects.isNull(authenticationDTO)) {
 			return reviewService.getReview(reviewId);
 		}
-		if (hasNotViewedReview(authenticationDTO.memberId(), reviewId)) {
+		if (doNotViewReview(authenticationDTO.memberId(), reviewId)) {
 			controlViewCountConcurrency(authenticationDTO.memberId(), reviewId);
 		}
 
@@ -91,7 +91,7 @@ public class ReviewRedisFacade {
 		return "memberId" + "_" + memberId + ", " + "reviewId" + "_" + reviewId;
 	}
 
-	private boolean hasNotViewedReview(Long memberId, Long reviewId) {
+	private boolean doNotViewReview(Long memberId, Long reviewId) {
 		String userViewedReviewLog = generateUserViewedReviewLog(memberId, reviewId);
 		return !redissonClient.getSet(USER_VIEWED_REVIEW_LOGS_NAME).contains(userViewedReviewLog);
 	}

--- a/src/main/java/com/goodseats/seatviewreviews/domain/stadium/controller/StadiumController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/stadium/controller/StadiumController.java
@@ -2,10 +2,10 @@ package com.goodseats.seatviewreviews.domain.stadium.controller;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.goodseats.seatviewreviews.domain.stadium.model.dto.response.StadiumDetailResponse;
 import com.goodseats.seatviewreviews.domain.stadium.model.dto.response.StadiumsResponse;
@@ -13,7 +13,7 @@ import com.goodseats.seatviewreviews.domain.stadium.service.StadiumService;
 
 import lombok.RequiredArgsConstructor;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/stadiums")
 public class StadiumController {

--- a/src/main/java/com/goodseats/seatviewreviews/domain/vote/controller/ReviewVoteController.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/vote/controller/ReviewVoteController.java
@@ -11,7 +11,6 @@ import javax.validation.Valid;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.SessionAttribute;
 
 import com.goodseats.seatviewreviews.common.security.Authority;
@@ -31,7 +31,7 @@ import com.goodseats.seatviewreviews.domain.vote.service.ReviewVoteService;
 
 import lombok.RequiredArgsConstructor;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/reviewvotes")
 public class ReviewVoteController {

--- a/src/main/resources/static/docs/rest-docs.html
+++ b/src/main/resources/static/docs/rest-docs.html
@@ -620,99 +620,19 @@ Host: localhost:8080</code></pre>
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 2257
+Content-Length: 318
 
 {
   "stadiums" : [ {
-    "stadiumId" : 1,
+    "stadiumId" : 59,
     "name" : "잠실 야구장",
     "homeTeam" : "DOOSAN_LG"
   }, {
-    "stadiumId" : 2,
-    "name" : "한화생명 이글스 파크",
-    "homeTeam" : "HANWHA"
-  }, {
-    "stadiumId" : 3,
-    "name" : "광주 기아 챔피언스 필드",
-    "homeTeam" : "KIA"
-  }, {
-    "stadiumId" : 4,
-    "name" : "고척 스카이돔",
-    "homeTeam" : "KIWOOM"
-  }, {
-    "stadiumId" : 5,
-    "name" : "수원KT위즈파크",
-    "homeTeam" : "KT"
-  }, {
-    "stadiumId" : 6,
-    "name" : "사직 야구장",
-    "homeTeam" : "LOTTE"
-  }, {
-    "stadiumId" : 7,
-    "name" : "창원NC파크",
-    "homeTeam" : "NC"
-  }, {
-    "stadiumId" : 8,
-    "name" : "대구 삼성 라이온즈 파크",
-    "homeTeam" : "SAMSUNG"
-  }, {
-    "stadiumId" : 9,
-    "name" : "인천SSG 랜더스필드",
-    "homeTeam" : "SSG"
-  }, {
-    "stadiumId" : 797,
+    "stadiumId" : 89,
     "name" : "잠실 야구장",
     "homeTeam" : "DOOSAN_LG"
   }, {
-    "stadiumId" : 799,
-    "name" : "잠실 야구장",
-    "homeTeam" : "DOOSAN_LG"
-  }, {
-    "stadiumId" : 805,
-    "name" : "잠실 야구장",
-    "homeTeam" : "DOOSAN_LG"
-  }, {
-    "stadiumId" : 1097,
-    "name" : "잠실 야구장",
-    "homeTeam" : "DOOSAN_LG"
-  }, {
-    "stadiumId" : 1098,
-    "name" : "잠실 야구장",
-    "homeTeam" : "DOOSAN_LG"
-  }, {
-    "stadiumId" : 2801,
-    "name" : "잠실 야구장",
-    "homeTeam" : "DOOSAN_LG"
-  }, {
-    "stadiumId" : 2838,
-    "name" : "잠실 야구장",
-    "homeTeam" : "DOOSAN_LG"
-  }, {
-    "stadiumId" : 2842,
-    "name" : "잠실 야구장",
-    "homeTeam" : "DOOSAN_LG"
-  }, {
-    "stadiumId" : 2843,
-    "name" : "잠실 야구장",
-    "homeTeam" : "DOOSAN_LG"
-  }, {
-    "stadiumId" : 2845,
-    "name" : "잠실 야구장",
-    "homeTeam" : "DOOSAN_LG"
-  }, {
-    "stadiumId" : 2855,
-    "name" : "잠실 야구장",
-    "homeTeam" : "DOOSAN_LG"
-  }, {
-    "stadiumId" : 2857,
-    "name" : "잠실 야구장",
-    "homeTeam" : "DOOSAN_LG"
-  }, {
-    "stadiumId" : 3140,
-    "name" : "잠실 야구장",
-    "homeTeam" : "DOOSAN_LG"
-  }, {
-    "stadiumId" : 3141,
+    "stadiumId" : 90,
     "name" : "한화생명 이글스 파크",
     "homeTeam" : "HANWHA"
   } ]
@@ -769,7 +689,7 @@ Content-Length: 2257
             <h5 id="_request_2"><a class="link" href="#_request_2">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/stadiums/3139 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/stadiums/88 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -931,7 +851,7 @@ Content-Length: 221
   "url" : "/api/v1/stadiums/-1",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-25 00:23:01",
+  "createdAt" : "2023-09-01 19:04:16",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -1001,7 +921,7 @@ Content-Length: 221
             <h5 id="_request_4"><a class="link" href="#_request_4">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/sections?stadiumId=3154 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/sections?stadiumId=103 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -1055,14 +975,14 @@ Host: localhost:8080</code></pre>
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 147
+Content-Length: 143
 
 {
   "seatSections" : [ {
-    "sectionId" : 2908,
+    "sectionId" : 94,
     "sectionName" : "110"
   }, {
-    "sectionId" : 2909,
+    "sectionId" : 95,
     "sectionName" : "111"
   } ]
 }</code></pre>
@@ -1113,7 +1033,7 @@ Content-Length: 147
             <h5 id="_request_5"><a class="link" href="#_request_5">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/seats?sectionId=2910 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/seats?sectionId=96 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -1293,7 +1213,7 @@ loginEmail=goodseat%40google.com&amp;password=password&amp;nickname=Jerome</code
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Location: /api/v1/members/6953</code></pre>
+Location: /api/v1/members/3927</code></pre>
               </div>
             </div>
           </div>
@@ -1375,7 +1295,7 @@ Content-Length: 209
   "url" : "/api/v1/members",
   "exceptionName" : "DuplicatedException",
   "message" : "중복된 아이디입니다.",
-  "createdAt" : "2023-08-25 00:23:30",
+  "createdAt" : "2023-09-01 19:04:29",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -1508,7 +1428,7 @@ Content-Length: 209
   "url" : "/api/v1/members",
   "exceptionName" : "DuplicatedException",
   "message" : "중복된 아이디입니다.",
-  "createdAt" : "2023-08-25 00:23:30",
+  "createdAt" : "2023-09-01 19:04:29",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -1709,7 +1629,7 @@ Content-Length: 236
   "url" : "/api/v1/members/login",
   "exceptionName" : "AuthenticationException",
   "message" : "아이디 혹은 비밀번호가 틀립니다.",
-  "createdAt" : "2023-08-25 00:23:29",
+  "createdAt" : "2023-09-01 19:04:29",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -1838,7 +1758,7 @@ Content-Length: 236
   "url" : "/api/v1/members/login",
   "exceptionName" : "AuthenticationException",
   "message" : "아이디 혹은 비밀번호가 틀립니다.",
-  "createdAt" : "2023-08-25 00:23:30",
+  "createdAt" : "2023-09-01 19:04:29",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -1941,7 +1861,7 @@ Content-Length: 230
   "url" : "/api/v1/members/logout",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-25 00:23:28",
+  "createdAt" : "2023-09-01 19:04:28",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2110,11 +2030,11 @@ testContent
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 149
+Content-Length: 148
 
 {
-  "imageId" : 855,
-  "imageUrl" : "https://seat-view-reviews.s3.ap-northeast-2.amazonaws.com/reviews/b5facf8a-1acd-4a4f-98a0-0a0115f48d94.png"
+  "imageId" : 18,
+  "imageUrl" : "https://seat-view-reviews.s3.ap-northeast-2.amazonaws.com/reviews/299751d0-90a2-44d7-9ec8-72c3a00370bc.png"
 }</code></pre>
               </div>
             </div>
@@ -2261,7 +2181,7 @@ Content-Length: 222
   "url" : "/api/v1/images",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-25 00:23:33",
+  "createdAt" : "2023-09-01 19:04:30",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2429,7 +2349,7 @@ Content-Length: 230
   "url" : "/api/v1/images",
   "exceptionName" : "IllegalArgumentException",
   "message" : "잘못된 이미지 업로드 요청입니다.",
-  "createdAt" : "2023-08-25 00:23:33",
+  "createdAt" : "2023-09-01 19:04:30",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2574,7 +2494,7 @@ Host: localhost:8080
             <h5 id="_request_18"><a class="link" href="#_request_18">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/images/856 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/images/19 HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
@@ -2656,7 +2576,7 @@ Content-Length: 218
   "url" : "/api/v1/images/1",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-25 00:23:33",
+  "createdAt" : "2023-09-01 19:04:30",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2718,7 +2638,7 @@ Content-Length: 218
             <h5 id="_request_20"><a class="link" href="#_request_20">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/images/857 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/images/20 HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
@@ -2751,14 +2671,14 @@ Host: localhost:8080</code></pre>
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 409 Conflict
 Content-Type: application/json
-Content-Length: 219
+Content-Length: 218
 
 {
   "status" : 409,
-  "url" : "/api/v1/images/857",
+  "url" : "/api/v1/images/20",
   "exceptionName" : "DuplicatedException",
   "message" : "이미 삭제된 데이터입니다.",
-  "createdAt" : "2023-08-25 00:23:33",
+  "createdAt" : "2023-09-01 19:04:30",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -2831,11 +2751,11 @@ Content-Length: 219
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/reviews HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Content-Length: 24
+Content-Length: 21
 Host: localhost:8080
 
 {
-  "seatId" : 27015
+  "seatId" : 79
 }</code></pre>
               </div>
             </div>
@@ -2894,7 +2814,7 @@ Host: localhost:8080
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Location: /api/v1/reviews/418</code></pre>
+Location: /api/v1/reviews/156</code></pre>
               </div>
             </div>
           </div>
@@ -2979,7 +2899,7 @@ Content-Length: 217
   "url" : "/api/v1/reviews",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-25 00:23:16",
+  "createdAt" : "2023-09-01 19:04:26",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3044,7 +2964,7 @@ Content-Length: 217
             <h5 id="_request_23"><a class="link" href="#_request_23">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/reviews/427 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/reviews/165 HTTP/1.1
 Content-Type: application/x-www-form-urlencoded;charset=UTF-8
 Host: localhost:8080</code></pre>
               </div>
@@ -3225,7 +3145,7 @@ Content-Length: 219
   "url" : "/api/v1/reviews/1",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-25 00:23:26",
+  "createdAt" : "2023-09-01 19:04:28",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3372,10 +3292,10 @@ Content-Length: 227
 
 {
   "status" : 401,
-  "url" : "/api/v1/reviews/439",
+  "url" : "/api/v1/reviews/177",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-25 00:23:20",
+  "createdAt" : "2023-09-01 19:04:27",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3440,7 +3360,7 @@ Content-Length: 227
             <h5 id="_request_24"><a class="link" href="#_request_24">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews?seatId=27018&amp;page=0&amp;size=1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews?seatId=82&amp;page=0&amp;size=1 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -3506,7 +3426,7 @@ Content-Length: 153
 
 {
   "reviews" : [ {
-    "reviewId" : 424,
+    "reviewId" : 162,
     "title" : "테스트 제목",
     "score" : 5,
     "viewCount" : 0,
@@ -3638,7 +3558,7 @@ Content-Length: 217
   "url" : "/api/v1/reviews",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-25 00:23:16",
+  "createdAt" : "2023-09-01 19:04:25",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3703,7 +3623,7 @@ Content-Length: 217
             <h5 id="_request_25"><a class="link" href="#_request_25">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews/438 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews/176 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
               </div>
@@ -3757,7 +3677,6 @@ Host: localhost:8080</code></pre>
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: USER_KEY=9327e5ba-8d75-42c4-80a6-9786e18de40f; Path=/; Max-Age=86400; Expires=Fri, 25 Aug 2023 15:23:20 GMT; Secure; HttpOnly
 Content-Type: application/json
 Content-Length: 131
 
@@ -3876,7 +3795,6 @@ Host: localhost:8080</code></pre>
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 404 Not Found
-Set-Cookie: USER_KEY=32084a90-6419-4373-9eeb-c2a994f2a2c3; Path=/; Max-Age=86400; Expires=Fri, 25 Aug 2023 15:23:13 GMT; Secure; HttpOnly
 Content-Type: application/json
 Content-Length: 220
 
@@ -3885,7 +3803,7 @@ Content-Length: 220
   "url" : "/api/v1/reviews/-1",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-25 00:23:13",
+  "createdAt" : "2023-09-01 19:04:24",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -3961,7 +3879,7 @@ Content-Length: 50
 Host: localhost:8080
 
 {
-  "reviewId" : 399,
+  "reviewId" : 137,
   "voteChoice" : "LIKE"
 }</code></pre>
               </div>
@@ -4022,7 +3940,7 @@ Host: localhost:8080
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Location: /api/v1/reviewvotes/659</code></pre>
+Location: /api/v1/reviewvotes/375</code></pre>
               </div>
             </div>
           </div>
@@ -4039,7 +3957,7 @@ Content-Length: 50
 Host: localhost:8080
 
 {
-  "reviewId" : 415,
+  "reviewId" : 153,
   "voteChoice" : "LIKE"
 }</code></pre>
               </div>
@@ -4108,7 +4026,7 @@ Content-Length: 227
   "url" : "/api/v1/reviewvotes",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-25 00:22:51",
+  "createdAt" : "2023-09-01 19:04:10",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4176,7 +4094,7 @@ Content-Length: 50
 Host: localhost:8080
 
 {
-  "reviewId" : 409,
+  "reviewId" : 147,
   "voteChoice" : "LIKE"
 }</code></pre>
               </div>
@@ -4245,7 +4163,7 @@ Content-Length: 221
   "url" : "/api/v1/reviewvotes",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-25 00:22:47",
+  "createdAt" : "2023-09-01 19:04:08",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4382,7 +4300,7 @@ Content-Length: 221
   "url" : "/api/v1/reviewvotes",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-25 00:22:49",
+  "createdAt" : "2023-09-01 19:04:09",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4450,7 +4368,7 @@ Content-Length: 50
 Host: localhost:8080
 
 {
-  "reviewId" : 411,
+  "reviewId" : 149,
   "voteChoice" : "LIKE"
 }</code></pre>
               </div>
@@ -4519,7 +4437,7 @@ Content-Length: 217
   "url" : "/api/v1/reviewvotes",
   "exceptionName" : "DuplicatedException",
   "message" : "이미 평가한 후기입니다.",
-  "createdAt" : "2023-08-25 00:22:48",
+  "createdAt" : "2023-09-01 19:04:08",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4584,7 +4502,7 @@ Content-Length: 217
             <h5 id="_request_32"><a class="link" href="#_request_32">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviewvotes/556 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviewvotes/272 HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
@@ -4666,7 +4584,7 @@ Content-Length: 223
   "url" : "/api/v1/reviewvotes/0",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-25 00:22:45",
+  "createdAt" : "2023-09-01 19:04:05",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4728,7 +4646,7 @@ Content-Length: 223
             <h5 id="_request_34"><a class="link" href="#_request_34">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviewvotes/663 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviewvotes/379 HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
@@ -4765,10 +4683,10 @@ Content-Length: 231
 
 {
   "status" : 401,
-  "url" : "/api/v1/reviewvotes/663",
+  "url" : "/api/v1/reviewvotes/379",
   "exceptionName" : "AuthenticationException",
   "message" : "인증되지 않은 사용자입니다.",
-  "createdAt" : "2023-08-25 00:22:46",
+  "createdAt" : "2023-09-01 19:04:06",
   "fieldErrors" : null
 }</code></pre>
               </div>
@@ -4833,7 +4751,7 @@ Content-Length: 231
             <h5 id="_request_35"><a class="link" href="#_request_35">Request</a></h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviewvotes?reviewId=403 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviewvotes?reviewId=141 HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
@@ -4961,7 +4879,7 @@ Content-Length: 221
   "url" : "/api/v1/reviewvotes",
   "exceptionName" : "NotFoundException",
   "message" : "존재하지 않는 데이터입니다.",
-  "createdAt" : "2023-08-25 00:22:42",
+  "createdAt" : "2023-09-01 19:04:03",
   "fieldErrors" : null
 }</code></pre>
               </div>


### PR DESCRIPTION
### 관련 이슈
- close #176 

### 내용
- 기존 방식은 userKey 쿠키에 UUID 를 담아서 사용자를 구분하고, UUID + 조회한 후기 id 형태의 데이터를 redis 에 저장하여 조회 수 중복 증가를 방지하였다. 하지만, 이 방식은 사용자가 쿠키를 비우면 새로운 사용자로 취급되므로 조회 수 어뷰징의 가능성이 있다. 그러므로, 회원만 조회 수 증가가 이루어지도록 방식을 변경하였다.