### PR TITLE
Refactor: redis 에서 최근 조회 수 조회하는 로직 성능 개선

### DIFF
--- a/src/main/java/com/goodseats/seatviewreviews/common/constant/RedisConstant.java
+++ b/src/main/java/com/goodseats/seatviewreviews/common/constant/RedisConstant.java
@@ -9,11 +9,9 @@ public class RedisConstant {
 	public static final String REDISSON_ADDRESS_PREFIX = "redis://";
 	public static final String USER_VIEWED_REVIEW_LOGS_NAME = "userViewedReviewLogs";
 	public static final String REVIEW_AND_VIEW_COUNT_LOGS_NAME = "reviewViewCountLogs";
-	public static final String DELIMITER = "_";
-	public static final String SEPARATOR = ", ";
 	public static final String VIEW_COUNT_LOCK = "viewCountLock";
 	public static final String REVIEW_VOTE_LOCK = "reviewVoteLock";
 	public static final int LOCK_WAIT_TIME = 10;
 	public static final int LEASE_TIME = 5;
-	public static final String VIEWED_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
+	public static final String REVIEW_AND_VIEW_COUNT_LOGS_NAME_PATTERN = "reviewViewCountLogs*";
 }

--- a/src/main/java/com/goodseats/seatviewreviews/domain/review/scheduler/ReviewScheduler.java
+++ b/src/main/java/com/goodseats/seatviewreviews/domain/review/scheduler/ReviewScheduler.java
@@ -3,16 +3,14 @@ package com.goodseats.seatviewreviews.domain.review.scheduler;
 import static com.goodseats.seatviewreviews.common.constant.RedisConstant.*;
 import static com.goodseats.seatviewreviews.common.constant.SchedulerConstant.*;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Comparator;
+import java.time.ZoneId;
 import java.util.List;
-import java.util.function.BinaryOperator;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
-import org.redisson.api.RMap;
+import org.redisson.api.RScoredSortedSet;
 import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.IntegerCodec;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +19,6 @@ import com.goodseats.seatviewreviews.common.error.exception.ErrorCode;
 import com.goodseats.seatviewreviews.common.error.exception.NotFoundException;
 import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
 import com.goodseats.seatviewreviews.domain.review.repository.ReviewRepository;
-import com.goodseats.seatviewreviews.domain.review.service.ReviewRedisFacade;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,74 +26,69 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ReviewScheduler {
 
-	private final ReviewRedisFacade reviewRedisFacade;
 	private final RedissonClient redissonClient;
 	private final ReviewRepository reviewRepository;
 
 	@Transactional
 	@Scheduled(cron = "0 */5 * * * *")
 	public void syncViewCountToDB() {
-		String previousScheduledMinute = getPreviousScheduledMinute();
-		List<String> targetKeys = getTargetsToSync(previousScheduledMinute);
-		updateViewCount(targetKeys);
+		LocalDateTime previousScheduledTime = getPreviousScheduledMinute();
+		List<String> reviewViewCountLogsViewedAfterPreviousScheduledTime
+				= getReviewViewCountLogsViewedAfterPreviousScheduledTime(previousScheduledTime);
+		updateReviewViewCount(reviewViewCountLogsViewedAfterPreviousScheduledTime);
 	}
 
 	@Scheduled(cron = "0 0 0 * * *")
 	public void clearViewCountLogs() {
-		reviewRedisFacade.clearAllLogs();
+		redissonClient.getSet(USER_VIEWED_REVIEW_LOGS_NAME).delete();
+		redissonClient.getKeys()
+				.getKeysStreamByPattern(REVIEW_AND_VIEW_COUNT_LOGS_NAME_PATTERN)
+				.forEach(reviewAndViewCountLogsKey -> redissonClient.getScoredSortedSet(reviewAndViewCountLogsKey).delete());
 	}
 
-	private String getPreviousScheduledMinute() {
+	private LocalDateTime getPreviousScheduledMinute() {
 		LocalDateTime now = LocalDateTime.now();
-		LocalDateTime previousScheduledMinute = now.minusMinutes(VIEW_COUNT_SCHEDULING_MINUTE);
-		return previousScheduledMinute.format(DateTimeFormatter.ofPattern(VIEWED_TIME_FORMAT));
+		return now.minusMinutes(VIEW_COUNT_SCHEDULING_MINUTE);
 	}
 
-	private List<String> getTargetsToSync(String previousScheduledMinute) {
-		RMap<String, String> reviewAndViewCountLogs = redissonClient.getMap(REVIEW_AND_VIEW_COUNT_LOGS_NAME);
-
-		return reviewAndViewCountLogs.keySet().stream()
-				.filter(key -> isTargetToSync(previousScheduledMinute, key))
-				.collect(Collectors.toMap(
-						this::extractReviewId,
-						Function.identity(),
-						BinaryOperator.maxBy(Comparator.comparing(this::extractViewedTime))
-				))
-				.values()
-				.stream()
+	private List<String> getReviewViewCountLogsViewedAfterPreviousScheduledTime(LocalDateTime previousScheduledTime) {
+		return redissonClient.getKeys()
+				.getKeysStreamByPattern(REVIEW_AND_VIEW_COUNT_LOGS_NAME_PATTERN)
+				.filter(reviewAndViewCountLogsName
+						-> lastViewedAfterPreviousScheduledTime(reviewAndViewCountLogsName, previousScheduledTime)
+				)
 				.toList();
 	}
 
-	private boolean isTargetToSync(String previousScheduledMinute, String key) {
-		int beforeViewedTimeIndex = key.lastIndexOf(DELIMITER);
-		String viewedTime = key.substring(beforeViewedTimeIndex + 1);
-		return viewedTime.compareTo(previousScheduledMinute) >= 0;
+	private boolean lastViewedAfterPreviousScheduledTime(String logName, LocalDateTime previousScheduledTime) {
+		RScoredSortedSet<Integer> reviewAndViewCountLogs = getReviewAndViewCountLogs(logName);
+
+		LocalDateTime lastViewedTime
+				= convertEpochMilliToLocalDateTime(reviewAndViewCountLogs.getScore(reviewAndViewCountLogs.last()).longValue());
+		return lastViewedTime.isAfter(previousScheduledTime);
 	}
 
-	private String extractReviewId(String key) {
-		int beforeReviewIdIndex = key.indexOf(DELIMITER);
-		int afterReviewIdIndex = key.indexOf(SEPARATOR);
-		return key.substring(beforeReviewIdIndex + 1, afterReviewIdIndex);
+	private RScoredSortedSet<Integer> getReviewAndViewCountLogs(String name) {
+		return redissonClient.getScoredSortedSet(name, new IntegerCodec());
 	}
 
-	private LocalDateTime extractViewedTime(String key) {
-		int beforeTimeIndex = key.lastIndexOf(DELIMITER);
-		String timeString = key.substring(beforeTimeIndex + 1);
-		return LocalDateTime.parse(timeString, DateTimeFormatter.ofPattern(VIEWED_TIME_FORMAT));
+	private LocalDateTime convertEpochMilliToLocalDateTime(long epochMillis) {
+		Instant instant = Instant.ofEpochMilli(epochMillis);
+		ZoneId zoneId = ZoneId.of("Asia/Seoul");
+		return instant.atZone(zoneId).toLocalDateTime();
 	}
 
-	private void updateViewCount(List<String> targetKeys) {
-		RMap<String, String> reviewAndViewCountLogs = redissonClient.getMap(REVIEW_AND_VIEW_COUNT_LOGS_NAME);
-
-		targetKeys
-				.forEach(key -> {
-					int viewCount = Integer.parseInt(reviewAndViewCountLogs.get(key));
-					Long reviewId = Long.valueOf(extractReviewId(key));
-
-					Review review = reviewRepository.findById(reviewId)
+	private void updateReviewViewCount(List<String> reviewViewCountLogs) {
+		reviewViewCountLogs
+				.forEach(logName -> {
+					Review review = reviewRepository.findById(extractReviewId(logName))
 							.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND));
-
-					review.updateViewCount(viewCount);
+					review.updateViewCount(getReviewAndViewCountLogs(logName).last());
 				});
+	}
+
+	private Long extractReviewId(String key) {
+		int beforeReviewIdIndex = REVIEW_AND_VIEW_COUNT_LOGS_NAME.length() - 1;
+		return Long.parseLong(key.substring(beforeReviewIdIndex + 1));
 	}
 }

--- a/src/test/java/com/goodseats/seatviewreviews/domain/review/scheduler/ReviewSchedulerTest.java
+++ b/src/test/java/com/goodseats/seatviewreviews/domain/review/scheduler/ReviewSchedulerTest.java
@@ -4,20 +4,22 @@ import static com.goodseats.seatviewreviews.common.constant.RedisConstant.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.redisson.api.RMap;
+import org.redisson.api.RKeys;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RSet;
 import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.IntegerCodec;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.goodseats.seatviewreviews.common.error.exception.ErrorCode;
@@ -25,7 +27,6 @@ import com.goodseats.seatviewreviews.common.error.exception.NotFoundException;
 import com.goodseats.seatviewreviews.domain.member.model.entity.Member;
 import com.goodseats.seatviewreviews.domain.review.model.entity.Review;
 import com.goodseats.seatviewreviews.domain.review.repository.ReviewRepository;
-import com.goodseats.seatviewreviews.domain.review.service.ReviewRedisFacade;
 import com.goodseats.seatviewreviews.domain.seat.model.entity.Seat;
 import com.goodseats.seatviewreviews.domain.seat.model.entity.SeatGrade;
 import com.goodseats.seatviewreviews.domain.seat.model.entity.SeatSection;
@@ -36,102 +37,129 @@ import com.goodseats.seatviewreviews.domain.stadium.model.vo.HomeTeam;
 class ReviewSchedulerTest {
 
 	@Mock
-	private ReviewRedisFacade reviewRedisFacade;
-
-	@Mock
 	private RedissonClient redissonClient;
 
 	@Mock
 	private ReviewRepository reviewRepository;
 
 	@Mock
-	private RMap<Object, Object> reviewAndViewCountLogs;
+	private RScoredSortedSet<Object> reviewAndViewCountLogs;
+
+	@Mock
+	private RSet<Object> userViewedReviewLogs;
+
+	@Mock
+	private RKeys rKeys;
 
 	@InjectMocks
 	private ReviewScheduler reviewScheduler;
+
+	private Member member;
+	private Stadium stadium;
+	private SeatGrade seatGrade;
+	private SeatSection seatSection;
+	private Seat seat;
+	private Review review;
+
+	@BeforeEach
+	void setUp() {
+		member = new Member("test@test.com", "test", "test");
+		ReflectionTestUtils.setField(member, "id", 1L);
+
+		stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
+		seatGrade = new SeatGrade("테이블", "주중 47,000 / 주말 53,000", stadium);
+		seatSection = new SeatSection("110", stadium, seatGrade);
+		seat = new Seat("1", seatGrade, seatSection);
+		ReflectionTestUtils.setField(seat, "id", 1L);
+
+		review = new Review(member, seat);
+		review.publish("테스트 제목", "테스트 내용", 5);
+		ReflectionTestUtils.setField(review, "id", 1L);
+	}
 
 	@Test
 	@DisplayName("Success - 스케줄링 주기마다 redis 에 저장된 조회 수를 DB 에 동기화한다")
 	void syncViewCountToDBSuccess() {
 		// given
-		Long seatId = 1L;
-		Long memberId = 1L;
-		Long reviewId = 1L;
+		List<String> keys = new ArrayList<>();
+		String key = REVIEW_AND_VIEW_COUNT_LOGS_NAME + review.getId();
+		keys.add(key);
 
-		Member member = new Member("test@test.com", "test", "test");
-		ReflectionTestUtils.setField(member, "id", memberId);
+		double nowTime = System.currentTimeMillis();
+		int latestViewCount = 100;
 
-		Stadium stadium = new Stadium("잠실 야구장", "서울 송파구 올림픽로 19-2 서울종합운동장", HomeTeam.DOOSAN_LG);
-		SeatGrade seatGrade = new SeatGrade("테이블", "주중 47,000 / 주말 53,000", stadium);
-		SeatSection seatSection = new SeatSection("110", stadium, seatGrade);
-		Seat seat = new Seat("1", seatGrade, seatSection);
-		ReflectionTestUtils.setField(seat, "id", seatId);
-
-		Review review = new Review(member, seat);
-		review.publish("테스트 제목", "테스트 내용", 5);
-		ReflectionTestUtils.setField(review, "id", reviewId);
-
-		String nowTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern(VIEWED_TIME_FORMAT));
-		String key = "reviewId" + "_" + reviewId + ", " + "viewedTime" + "_" + nowTime;
-		Set<Object> keySet = new HashSet<>();
-		keySet.add(key);
-
-		String latestViewCount = "100";
-
-		when(redissonClient.getMap(REVIEW_AND_VIEW_COUNT_LOGS_NAME)).thenReturn(reviewAndViewCountLogs);
-		when(reviewAndViewCountLogs.keySet()).thenReturn(keySet);
-		when(reviewAndViewCountLogs.get(key)).thenReturn(latestViewCount);
-		when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(review));
+		when(redissonClient.getKeys()).thenReturn(rKeys);
+		when(rKeys.getKeysStreamByPattern(REVIEW_AND_VIEW_COUNT_LOGS_NAME_PATTERN)).thenReturn(keys.stream());
+		when(redissonClient.getScoredSortedSet(eq(key), any(IntegerCodec.class))).thenReturn(reviewAndViewCountLogs);
+		when(reviewAndViewCountLogs.last()).thenReturn(latestViewCount);
+		when(reviewAndViewCountLogs.getScore(latestViewCount)).thenReturn(nowTime);
+		when(reviewRepository.findById(review.getId())).thenReturn(Optional.of(review));
 
 		// when
 		reviewScheduler.syncViewCountToDB();
 
 		// then
-		verify(redissonClient, times(2)).getMap(REVIEW_AND_VIEW_COUNT_LOGS_NAME);
-		verify(reviewAndViewCountLogs).keySet();
-		verify(reviewAndViewCountLogs).get(key);
-		verify(reviewRepository).findById(reviewId);
-		assertThat(review.getViewCount()).isEqualTo(Integer.parseInt(latestViewCount));
+		verify(redissonClient).getKeys();
+		verify(rKeys).getKeysStreamByPattern(REVIEW_AND_VIEW_COUNT_LOGS_NAME_PATTERN);
+		verify(redissonClient, times(2)).getScoredSortedSet(eq(key), any(IntegerCodec.class));
+		verify(reviewRepository).findById(review.getId());
+		assertThat(review.getViewCount()).isEqualTo(latestViewCount);
 	}
 
 	@Test
 	@DisplayName("Fail - redis 에 저장된 후기가 DB 에 없으면 동기화에 실패한다")
 	void syncViewCountToDBFailByNotFoundReview() {
 		// given
-		Long reviewId = 1L;
+		Long wrongReviewId = 2L;
 
-		String nowTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern(VIEWED_TIME_FORMAT));
-		String key = "reviewId" + "_" + reviewId + ", " + "viewedTime" + "_" + nowTime;
-		Set<Object> keySet = new HashSet<>();
-		keySet.add(key);
+		List<String> keys = new ArrayList<>();
+		String key = REVIEW_AND_VIEW_COUNT_LOGS_NAME + wrongReviewId;
+		keys.add(key);
 
-		String latestViewCount = "100";
+		double nowTime = System.currentTimeMillis();
+		int latestViewCount = 100;
 
-		when(redissonClient.getMap(REVIEW_AND_VIEW_COUNT_LOGS_NAME)).thenReturn(reviewAndViewCountLogs);
-		when(reviewAndViewCountLogs.keySet()).thenReturn(keySet);
-		when(reviewAndViewCountLogs.get(key)).thenReturn(latestViewCount);
-		when(reviewRepository.findById(reviewId)).thenReturn(Optional.empty());
+		when(redissonClient.getKeys()).thenReturn(rKeys);
+		when(rKeys.getKeysStreamByPattern(REVIEW_AND_VIEW_COUNT_LOGS_NAME_PATTERN)).thenReturn(keys.stream());
+		when(redissonClient.getScoredSortedSet(eq(key), any(IntegerCodec.class))).thenReturn(reviewAndViewCountLogs);
+		when(reviewAndViewCountLogs.last()).thenReturn(latestViewCount);
+		when(reviewAndViewCountLogs.getScore(latestViewCount)).thenReturn(nowTime);
+		when(reviewRepository.findById(wrongReviewId)).thenReturn(Optional.empty());
 
 		// when & then
 		assertThatThrownBy(() -> reviewScheduler.syncViewCountToDB())
 				.isExactlyInstanceOf(NotFoundException.class)
 				.hasMessage(ErrorCode.NOT_FOUND.getMessage());
-		verify(redissonClient, times(2)).getMap(REVIEW_AND_VIEW_COUNT_LOGS_NAME);
-		verify(reviewAndViewCountLogs).keySet();
-		verify(reviewAndViewCountLogs).get(key);
-		verify(reviewRepository).findById(reviewId);
+		verify(redissonClient).getKeys();
+		verify(rKeys).getKeysStreamByPattern(REVIEW_AND_VIEW_COUNT_LOGS_NAME_PATTERN);
+		verify(redissonClient).getScoredSortedSet(eq(key), any(IntegerCodec.class));
+		verify(reviewRepository).findById(wrongReviewId);
 	}
 
 	@Test
 	@DisplayName("Success - 스케줄링 주기마다 redis 에 저장된 조회 수 데이터를 제거한다")
 	void clearViewCountLogsSuccess() {
 		// given
-		doNothing().when(reviewRedisFacade).clearAllLogs();
+		List<String> keys = new ArrayList<>();
+		String key = REVIEW_AND_VIEW_COUNT_LOGS_NAME + review.getId();
+		keys.add(key);
+
+		when(redissonClient.getSet(USER_VIEWED_REVIEW_LOGS_NAME)).thenReturn(userViewedReviewLogs);
+		when(userViewedReviewLogs.delete()).thenReturn(true);
+		when(redissonClient.getKeys()).thenReturn(rKeys);
+		when(rKeys.getKeysStreamByPattern(REVIEW_AND_VIEW_COUNT_LOGS_NAME_PATTERN)).thenReturn(keys.stream());
+		when(redissonClient.getScoredSortedSet(any(String.class))).thenReturn(reviewAndViewCountLogs);
+		when(reviewAndViewCountLogs.delete()).thenReturn(true);
 
 		// when
 		reviewScheduler.clearViewCountLogs();
 
 		// then
-		verify(reviewRedisFacade).clearAllLogs();
+		verify(redissonClient).getSet(USER_VIEWED_REVIEW_LOGS_NAME);
+		verify(userViewedReviewLogs).delete();
+		verify(redissonClient).getKeys();
+		verify(rKeys).getKeysStreamByPattern(REVIEW_AND_VIEW_COUNT_LOGS_NAME_PATTERN);
+		verify(redissonClient).getScoredSortedSet(any(String.class));
+		verify(reviewAndViewCountLogs).delete();
 	}
 }


### PR DESCRIPTION
### 관련 이슈
- close #156 

### 내용
- 문제
  - 후기의 조회 수 데이터를 기존에는 (key, value) 가 ('후기 id + 조회 시간', '조회 수') 형태인 Map 에 저장했다. 그렇기에 조회 수 갱신 시 필요한 최신 조회 수 탐색 시 O(N) 의 시간이 걸렸다.
- 해결
  - Redis sorted set 을 이용하여 저장하였다. set 의 이름에 후기 id 를 포함해 후기를 구분할 수 있게 하고, set 의 score 로 조회 시간(유닉스타임 형식), value 로 조회 수를 저장하도록 하였다. 조회 시간을 score 로 두어 최신 조회 수를 O(1) 에 조회할 수 있게되었다.
- 결과
  - JMeter 를 활용하여 변경 전후를 비교해본 결과 데이터가 200개 있는 상황에서도 TPS 가 18% 가량 증가했다. 대규모로 데이터가 많을수록 TPS 가 월등히 개선될 것이다.